### PR TITLE
Test helper: HTTP response recorder

### DIFF
--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import { recordResponses } from './test_helper'
+const fs = require('fs');
+const axios = require('axios')
+
+describe("record stuff", () => {
+  async function getStuff() {
+    const backend = axios.create({
+      baseURL: "https://hub.dummyapis.com/",
+      withCredentials: false,
+      timeout: 1000,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      }
+    });
+    return backend.get("singlelist?text=Test&noofRecords=10").then(
+      (response) => { console.log(`Got ${response.status}`); return Promise.resolve(response.data) },
+      (error) => { return Promise.reject(error) }
+    );
+  }
+
+  afterEach(function() {
+    fs.unlink(__dirname + '/replies/get_singlelist_text-test_noofrecords-10.json', (error) => {
+      if (error) {
+        console.error(`Could not delete the file after test. Error: ${error}`);
+      }
+    });
+  });
+
+  it('records contents to a readable file', async function() {
+    return await recordResponses(async function() {
+      await getStuff();
+    }).then(function() {
+      const expectedFilePath = __dirname + '/replies/get_singlelist_text-test_noofrecords-10.json';
+      fs.access(expectedFilePath, fs.constants.R_OK, (error) => {
+        if (error) {
+          expect.fail(`File '${expectedFilePath}' not readable, got error: ${error}`);
+        }
+      });
+      fs.readFile(expectedFilePath, 'utf8', (error, data) => {
+        if (error) {
+          expect.fail(`Could not read file. Error: ${error}`)
+        } else {
+          const content = JSON.parse(data);
+          expect(content).to.eql(new Array(10).fill({value: 'Test'}))
+        }
+      })
+    });
+  });
+});

--- a/test/test_helper.ts
+++ b/test/test_helper.ts
@@ -1,0 +1,61 @@
+import nock = require('nock');
+const fs = require('fs');
+
+export async function recordResponses(callback) {
+  setupRecording();
+
+  await callback.call()
+
+  stopRecording();
+  saveFiles();
+  cleanup();
+}
+
+function setupRecording() {
+  nock.restore(); // Clear nock
+  nock.recorder.clear(); // Clear recorder
+  nock.recorder.rec({
+    dont_print: true, // No stdout output
+    output_objects: true // Returns objects instead of a string about recording
+  });
+}
+
+function stopRecording() {
+  nock.restore();
+}
+
+function saveFiles() {
+  const indentationSpaces = 2;
+  nock.recorder.play().forEach(function(record) {
+    const filePath = filenameFromRequest(record.method, record.path);
+    const json = JSON.stringify(record.response, null, indentationSpaces);
+    try {
+      fs.writeFileSync(filePath, json);
+      console.debug(`Response written to ${filePath}`);
+    } catch(error) {
+      console.error(error);
+    }
+  });
+}
+
+function filenameFromRequest(httpMethod, url) {
+  const extension = 'json';
+  const targetDir = __dirname + '/replies/';
+
+  const urlPathForFilename = url
+    .replace(/^\//g, '') // Remove leading slash
+    .replace(/=/g, "-") // Convert all '=' to '-', for example, 'foo?bar=1' becomes 'foo?bar-1'
+    .replace(/[^\w-]+/g, "_") // Leave alphanumeric characters and dashes as is, convert everything else to underscores
+    .toLowerCase() // Preventing filename case sensitivity issues before they become a pain
+
+  const httpMethodForFilename = httpMethod.toLowerCase(); // Preventing filename case sensitivity issues
+  const filename = `${httpMethodForFilename}_${urlPathForFilename}.${extension}`
+  const absolutePath = targetDir + filename;
+
+  return absolutePath;
+}
+
+function cleanup() {
+  nock.recorder.clear();
+  console.debug("Finished recording responses");
+}


### PR DESCRIPTION
Record actual server responses into JSON fixtures to be later used with nock, instead of manually copy-pasting server response into those fixture files.