### PR TITLE
ElectionConfig now directly answers messages about the data it contains

### DIFF
--- a/lib/av_client/election_config.ts
+++ b/lib/av_client/election_config.ts
@@ -1,11 +1,18 @@
 export default class ElectionConfig {
   bulletinBoard: any;
+  data: any;
 
   constructor(bulletinBoard) {
     this.bulletinBoard = bulletinBoard;
+    this.data = {}
   }
 
-  async get() {
+  /**
+   * Attempts to populate election configuration data from backend server, if it hasn't been populated yet.
+   */
+  async fetch() {
+    if (Object.entries(this.data).length !== 0) return;
+
     return this.bulletinBoard.getElectionConfig()
       .then(
         (response) => {
@@ -16,9 +23,37 @@ export default class ElectionConfig {
             'http://localhost:1111',
             'http://localhost:2222'
           ]
-          return configData;
+          this.data = configData;
         },
         (error) => { return Promise.reject(error) }
       );
+  }
+
+  OTPProviderCount() {
+    return this.data.OTPProviderCount;
+  }
+
+  OTPProviderURLs() {
+    return this.data.OTPProviderURLs;
+  }
+
+  voterAuthorizationCoordinatorURL() {
+    return this.data.voterAuthorizationCoordinatorURL;
+  }
+
+  ballots() {
+    return this.data.ballots;
+  }
+
+  electionId() {
+    return this.data.election.id;
+  }
+
+  encryptionKey() {
+    return this.data.encryptionKey;
+  }
+
+  signingPublicKey() {
+    return this.data.signingPublicKey;
   }
 }


### PR DESCRIPTION
I felt this was a change that would make implementing 'a public method to ask for authorization mode' much easier.

Potential benefit in communication: having `this.electionConfig.something()` calls shows which values come directly from election config, as opposed to being calculated on the device/consumer-application.