### PR TITLE
AVClient#authorizationMethod

### DIFF
--- a/lib/av_client.ts
+++ b/lib/av_client.ts
@@ -41,6 +41,29 @@ export class AVClient {
     this.electionConfig = {};
   }
 
+  authorizationMethod(): { methodName: string; method: Function } {
+    if (!this.electionConfig) {
+      throw new Error('Please fetch election config first');
+    }
+
+    switch(this.electionConfig.authorizationMode) {
+      case 'election codes':
+        return {
+          methodName: 'authenticateWithCodes',
+          method: this.authenticateWithCodes
+        }
+        break;
+      case 'otps':
+        return {
+          methodName: 'initiateDigitalReturn',
+          method: this.initiateDigitalReturn
+        }
+        break;
+      default:
+        throw new Error('Authorization method not found in election config')
+    }
+  }
+
   /**
    * Authenticates or rejects voter, based on their submitted election codes.
    * @param codes Array of election code strings.

--- a/test/authorization_method.test.ts
+++ b/test/authorization_method.test.ts
@@ -1,0 +1,44 @@
+import { AVClient } from '../lib/av_client';
+import { expect } from 'chai';
+
+describe('AVClient#authorizationMethod', function() {
+  let client;
+  let sandbox;
+
+  beforeEach(function() {
+    client = new AVClient('http://localhost:3000/test/app');
+    client.electionConfig = require('./replies/config.valid.json');
+  });
+
+  context('bulletin board returns a config, mode is election codes', function() {
+    it('returns the appropriate method name', function() {
+      client.electionConfig.authorizationMode = 'election codes';
+      const result = client.authorizationMethod();
+      expect(result.methodName).to.equal('authenticateWithCodes');
+      expect(result.method).to.equal(client.authenticateWithCodes);
+    });
+  });
+
+  context('bulletin board returns a config, mode is OTPs', function() {
+    it('returns the appropriate method name', function() {
+      client.electionConfig.authorizationMode = 'otps';
+      const result = client.authorizationMethod();
+      expect(result.methodName).to.equal('initiateDigitalReturn');
+      expect(result.method).to.equal(client.initiateDigitalReturn);
+    })
+  });
+
+  context('election config is not available', function() {
+    it('returns an error', function() {
+      delete client['electionConfig'];
+      expect(() => client.authorizationMethod()).to.throw(Error, 'Please fetch election config first');
+    })
+  });
+
+  context('election config value for authorization mode is not available', function() {
+    it('returns an error', function() {
+      delete client.electionConfig['authorizationMode'];
+      expect(() => client.authorizationMethod()).to.throw(Error, 'Authorization method not found in election config');
+    })
+  });
+});


### PR DESCRIPTION
Depending on config value 'authorizationMode',
will return an object containing method name as a string,
and a reference to the actual instance method.

Throws an error if election hasn't been fetched yet,
or found value is unsupported.