### PR TITLE
Test coverage command

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aion-dk/js-client",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "dependencies": {
         "axios": "^0.21.1"
       },
       "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@types/chai": "^4.2.20",
         "@types/mocha": "^8.2.3",
         "@types/node": "^16.0.0",
@@ -19,6 +20,7 @@
         "nock": "^13.1.1",
         "nyc": "^15.1.0",
         "sinon": "^11.1.1",
+        "source-map-support": "^0.5.19",
         "ts-node": "^10.0.0",
         "typedoc": "^0.21.2",
         "typedoc-plugin-markdown": "^3.10.2",
@@ -513,6 +515,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
+      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "nyc": ">=15",
+        "source-map-support": "*",
+        "ts-node": "*"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -3584,6 +3603,15 @@
             "p-limit": "^2.2.0"
           }
         }
+      }
+    },
+    "@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
+      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2"
       }
     },
     "@istanbuljs/schema": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",
   "scripts": {
-    "test": "mocha --require ts-node/register --extension ts ./test/*.test.ts",
-    "tdd": "mocha --require ts-node/register ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
+    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/*.test.ts",
+    "coverage": "tsc && nyc --reporter=text npm run test",
+    "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc",
     "html_docs": "typedoc --plugin none --out html_docs",
     "prepublish": "tsc && typedoc"
@@ -15,6 +16,7 @@
     "axios": "^0.21.1"
   },
   "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/chai": "^4.2.20",
     "@types/mocha": "^8.2.3",
     "@types/node": "^16.0.0",
@@ -23,6 +25,7 @@
     "nock": "^13.1.1",
     "nyc": "^15.1.0",
     "sinon": "^11.1.1",
+    "source-map-support": "^0.5.19",
     "ts-node": "^10.0.0",
     "typedoc": "^0.21.2",
     "typedoc-plugin-markdown": "^3.10.2",


### PR DESCRIPTION
`npm run coverage` will now run test suite and print out a coverage report
in the terminal.