### PR TITLE
 Renamed `fingerprint` to `trackingCode`

### DIFF
--- a/docs/classes/avclient.md
+++ b/docs/classes/avclient.md
@@ -41,8 +41,8 @@ describe('entire voter flow using OTP authorization', () => {
     expect(validateAccessCodeResult).to.eq('OK');
 
     const cvr = { '1': 'option1', '2': 'optiona' };
-    const fingerprint = await client.constructBallotCryptograms(cvr);
-    expect(fingerprint).to.eq('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
+    const trackingCode  = await client.constructBallotCryptograms(cvr);
+    expect(trackingCode).to.eq('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
 
     const affidavit = 'some bytes, most likely as binary PDF';
     const receipt = await client.submitBallotCryptograms(affidavit);
@@ -152,7 +152,7 @@ Example:
 ```javascript
 const client = new AVClient(url);
 const cvr = { '1': 'option1', '2': 'optiona' };
-const fingerprint = await client.constructBallotCryptograms(cvr);
+const trackingCode = await client.constructBallotCryptograms(cvr);
 ```
 
 Where `'1'` and `'2'` are contest ids, and `'option1'` and `'optiona'` are
@@ -171,7 +171,7 @@ or [submitBallotCryptograms](avclient.md#submitballotcryptograms).
 
 `Promise`<`string`\>
 
-Returns fingerprint of the cryptograms. Example:
+Returns the ballot tracking code. Example:
 ```javascript
 '5e4d8fe41fa3819cc064e2ace0eda8a847fe322594a6fd5a9a51c699e63804b7'
 ```

--- a/lib/av_client.ts
+++ b/lib/av_client.ts
@@ -196,7 +196,7 @@ export class AVClient {
    * ```javascript
    * const client = new AVClient(url);
    * const cvr = { '1': 'option1', '2': 'optiona' };
-   * const fingerprint = await client.constructBallotCryptograms(cvr);
+   * const trackingCode = await client.constructBallotCryptograms(cvr);
    * ```
    *
    * Where `'1'` and `'2'` are contest ids, and `'option1'` and `'optiona'` are
@@ -206,7 +206,7 @@ export class AVClient {
    * or {@link AVClient.submitBallotCryptograms | submitBallotCryptograms}.
    *
    * @param   cvr Object containing the selections for each contest.<br>TODO: needs better specification.
-   * @returns Returns fingerprint of the cryptograms. Example:
+   * @returns Returns the ballot tracking code. Example:
    * ```javascript
    * '5e4d8fe41fa3819cc064e2ace0eda8a847fe322594a6fd5a9a51c699e63804b7'
    * ```
@@ -243,10 +243,10 @@ export class AVClient {
 
     this.voteEncryptions = encryptionResponse
 
-    const fingerprint = new EncryptVotes().fingerprint(this.cryptogramsForConfirmation());
+    const trackingCode = new EncryptVotes().fingerprint(this.cryptogramsForConfirmation());
     this.succeededMethods.push('constructBallotCryptograms');
 
-    return fingerprint;
+    return trackingCode;
   }
 
   /**

--- a/test/construct_ballot_cryptograms.test.ts
+++ b/test/construct_ballot_cryptograms.test.ts
@@ -47,9 +47,9 @@ describe('AVClient#constructBallotCryptograms', () => {
 
       const cvr = { '1': 'option1', '2': 'optiona' };
 
-      const fingerprint = await client.constructBallotCryptograms(cvr);
+      const trackingCode = await client.constructBallotCryptograms(cvr);
 
-      expect(fingerprint).to.equal('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
+      expect(trackingCode).to.equal('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
     });
   });
 

--- a/test/readme_example.test.ts
+++ b/test/readme_example.test.ts
@@ -16,8 +16,8 @@ describe('entire voter flow using OTP authorization', () => {
     expect(validateAccessCodeResult).to.eq('OK');
 
     const cvr = { '1': 'option1', '2': 'optiona' };
-    const fingerprint = await client.constructBallotCryptograms(cvr);
-    expect(fingerprint).to.eq('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
+    const trackingCode  = await client.constructBallotCryptograms(cvr);
+    expect(trackingCode).to.eq('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
 
     const affidavit = 'some bytes, most likely as binary PDF';
     const receipt = await client.submitBallotCryptograms(affidavit);

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -57,11 +57,11 @@ describe('entire voter flow using OTP authorization', () => {
     });
 
     const cvr = { '1': 'option1', '2': 'optiona' };
-    const fingerprint = await client.constructBallotCryptograms(cvr).catch((e) => {
+    const trackingCode = await client.constructBallotCryptograms(cvr).catch((e) => {
       console.error(e);
       expect.fail('AVClient#constructBallotCryptograms failed');
     });
-    expect(fingerprint).to.eql('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
+    expect(trackingCode).to.eql('da46ec752fd9197c0d77e6d843924b082b8b23350e8ac5fd454051dc1bf85ad2');
 
     const affidavit = 'some bytes, most likely as binary PDF';
     const receipt = await client.submitBallotCryptograms(affidavit).catch((e) => {


### PR DESCRIPTION
I left the  `EncryptVotes#fingerprint` method because that is an internal method that we use. An I argue that the naming makes sense there.
I renamed `fingerprint` to `trackingCode` only where we expose it to the outside.