### PR TITLE
Code coverage badge commit messages include coverage value

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
             git config --local user.email "action@github.com"
             git config --local user.name "Github Action"
             git add .github/coverage_badge.svg
-            git commit -m "Updated coverage badge"
+            git commit -m "Updated coverage badge to $coverage_percentage %"
           else
             echo 'Coverage remains the same'
           fi


### PR DESCRIPTION
Currently, rendering git history for the coverage badge file doesn't provide much value:
![Screenshot 2021-09-20 at 09 56 14](https://user-images.githubusercontent.com/85161335/133971522-5475deba-d03f-4b0c-8700-ec0f4c51aea4.png)

This changes adds the actual percentage to commit message, so the list would nicely describe how the value changes.