### PR TITLE
Add voter_authorizer and otp_provider urls in election config

### DIFF
--- a/lib/av_client/election_config.ts
+++ b/lib/av_client/election_config.ts
@@ -14,7 +14,15 @@ export interface ElectionConfig {
   affidavit: AffidavitConfig;
 
   authorizationMode: 'election codes' | 'otps';
-  services: any; // TODO: Sune, please help us improve this
+
+  services: {
+    'voter_authorizer': Service,
+    'otp_provider': Service
+  };
+}
+
+interface Service {
+  url: string;
 }
 
 interface AffidavitConfig {


### PR DESCRIPTION
Allow the client lib to access URLs for voter authorizer and otp provider through the election config. We'll add the publicKey of each to the type, once it's ready on the backend.