### PR TITLE
Disable typedoc on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --includes test/",
     "html_docs": "typedoc --plugin none --out html_docs --includes test/",
-    "prepublish": "tsc && typedoc --includes test/",
+    "prepublish": "tsc",
     "build": "tsc && cp lib/av_client/*.js dist/lib/av_client",
     "lint": "eslint lib/"
   },


### PR DESCRIPTION
The markdown based docs are slightly broken using the latest typedoc
(and related) packages. Generation yields an invalid result when using
includes. I suggest we disable for the time being.