### PR TITLE
Removed unused previously recorded replies

### DIFF
--- a/test/replies/avx_error.invalid_4.json
+++ b/test/replies/avx_error.invalid_4.json
@@ -1,6 +1,0 @@
-{
-  "error": {
-    "code": 4,
-    "description": "Ballot ids do not correspond."
-  }
-}

--- a/test/replies/avx_error.invalid_5.json
+++ b/test/replies/avx_error.invalid_5.json
@@ -1,6 +1,0 @@
-{
-  "error": {
-    "code": 5,
-    "description": "Digital signature did not validate."
-  }
-}

--- a/test/replies/avx_error.invalid_6.json
+++ b/test/replies/avx_error.invalid_6.json
@@ -1,6 +1,0 @@
-{
-  "error": {
-    "code": 6,
-    "description": "Content hash does not correspond."
-  }
-}

--- a/test/replies/avx_error.invalid_7.json
+++ b/test/replies/avx_error.invalid_7.json
@@ -1,6 +1,0 @@
-{
-  "error": {
-    "code": 7,
-    "description": "Proof of correct encryption failed for ballot #1."
-  }
-}


### PR DESCRIPTION
A global search of "avx_error.invalid" shows that only avx_error.invalid_2.json & avx_error.invalid_3.json are used.