### PR TITLE
Exclude docs and sjcl.js from coverage reports

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,8 +3,10 @@
   "all": true,
   "exclude": [
     "dist/*",
+    "docs/*",
     "html_docs/*",
     "typedoc-wide-theme/*",
-    "test/*"
+    "test/*",
+    "lib/av_client/sjcl.js"
   ]
 }


### PR DESCRIPTION
Docs don't contain code, and sjcl.js is presumably [passing tests](https://travis-ci.org/github/bitwiseshiftleft/sjcl).