### PR TITLE
Less deterministic test assertions

### DIFF
--- a/test/readme_example.test.ts
+++ b/test/readme_example.test.ts
@@ -31,8 +31,6 @@ describe('entire voter flow using OTP authorization', () => {
       'serverSignature',
       'voteSubmissionId'
     );
-    expect(receipt.previousBoardHash).to.eql('b8c006ae94b5f98d684317beaf4784938fc6cf2921d856cc3c8416ea4b510a30');
-    expect(receipt.registeredAt).to.eql('2020-03-01T10:00:00.000+01:00');
-    expect(receipt.voteSubmissionId).to.eql(7);
+    expect(receipt.previousBoardHash.length).to.eql(64);
   });
 });

--- a/test/submit_ballot_cryptograms.test.ts
+++ b/test/submit_ballot_cryptograms.test.ts
@@ -62,9 +62,7 @@ describe('AVClient#submitBallotCryptograms', () => {
         'serverSignature',
         'voteSubmissionId'
       );
-      expect(receipt.previousBoardHash).to.eql('b8c006ae94b5f98d684317beaf4784938fc6cf2921d856cc3c8416ea4b510a30');
-      expect(receipt.registeredAt).to.eql('2020-03-01T10:00:00.000+01:00');
-      expect(receipt.voteSubmissionId).to.eql(7);
+      expect(receipt.previousBoardHash.length).to.eql(64);
     });
   });
 

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -9,7 +9,7 @@ import {
 } from './test_helpers';
 import { recordResponses } from './test_helpers'
 
-const USE_MOCK = true
+const USE_MOCK = true;
 
 describe('entire voter flow using OTP authorization', () => {
   let sandbox;
@@ -82,9 +82,7 @@ describe('entire voter flow using OTP authorization', () => {
         'serverSignature',
         'voteSubmissionId'
       )
-      expect(receipt.previousBoardHash).to.eql('b8c006ae94b5f98d684317beaf4784938fc6cf2921d856cc3c8416ea4b510a30')
-      expect(receipt.registeredAt).to.eql('2020-03-01T10:00:00.000+01:00')
-      expect(receipt.voteSubmissionId).to.eql(7)
+      expect(receipt.previousBoardHash.length).to.eql(64)
 
       if(USE_MOCK)
         expectedNetworkRequests.forEach((mock) => mock.done());


### PR DESCRIPTION
These changes would allow us to get rid of deterministic mode from AVX entirely.
AVX database needs to be reset with specific settings before each recording of all calls,
which we mostly have to do anyway.