### PR TITLE
Change transpilation target from ES2020 to ES2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "sourceMap": true,
-    "target": "ES2020",
+    "target": "ES2018",
     "isolatedModules": true,
     "declaration": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Using ES2020 features in the output, causes problems in the US Ionic
app. Specifically the use of the optional chaining  operator '?'.

Using ES2018 seems to fix it.