### PR TITLE
Export errors correctly

### DIFF
--- a/lib/av_client.ts
+++ b/lib/av_client.ts
@@ -431,7 +431,7 @@ type AffidavitConfig = {
 
 export type { CastVoteRecord, Affidavit, BallotBoxReceipt }
 
-export type {
+export {
   AccessCodeExpired,
   AccessCodeInvalid,
   BulletinBoardError,


### PR DESCRIPTION
We had an issue in the way error types were exported which prevented the consumers from writing proper error handling code like:

```
try {
...
} catch(error: Error) {
  if(error instanceof InvalidConfigError) {
  ...
  }
}
```