### PR TITLE
Fix missing js files in published package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,6 @@ jobs:
       - run: ls -l dist/lib/av_client/
       - run: npm run build
       - run: ls -l dist/lib/av_client/
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - run: npm publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,7 @@
 name: Package
-on: workflow_dispatch
+on:
+  release:
+    types: [created]
 jobs:
   publish-package:
     runs-on: ubuntu-20.04

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
       - run: npm run build
-      - run: ls -l dist/lib/av_client/
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,6 @@ jobs:
       - run: ls -l dist/lib/av_client/
       - run: npm run build
       - run: ls -l dist/lib/av_client/
-      # - run: npm publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
-      - run: npm install
       - run: npm run build
       - run: npm publish
         env:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
+      - run: ls -l dist/lib/av_client/
       - run: npm run build
+      - run: ls -l dist/lib/av_client/
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
-      - run: ls -l dist/lib/av_client/
       - run: npm run build
       - run: ls -l dist/lib/av_client/
       - run: npm publish

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --force
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # AV Client Library Changelog
 
+## 0.1.5
+* Fix problem with 3rd party libs not being contained in package.
+
 ## 0.1.3
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AV Client Library Changelog
 
-## 0.1.6
+## 0.1.7
 * Fix problem with 3rd party libs not being contained in package.
 
 ## 0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AV Client Library Changelog
 
-## 0.1.5
+## 0.1.6
 * Fix problem with 3rd party libs not being contained in package.
 
 ## 0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AV Client Library Changelog
 
-## 0.1.7
+## 0.1.8
 * Fix problem with 3rd party libs not being contained in package.
 
 ## 0.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "coverage": "tsc && nyc --reporter=json-summary --reporter=text npm run test",
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --plugin none --out docs --includes test/",
-    "prepublish": "tsc",
     "build": "tsc && cp lib/av_client/*.js dist/lib/av_client",
     "lint": "eslint lib/"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --plugin none --out docs --includes test/",
     "build": "tsc && cp lib/av_client/*.js dist/lib/av_client",
+    "prepublish": "tsc && cp lib/av_client/*.js dist/lib/av_client",
     "lint": "eslint lib/"
   },
   "dependencies": {


### PR DESCRIPTION
For some reason the aion_crypto.js + sjcl.js was missing in the published package.

This fixes that problem, as well as introduces automatic publishing when a release is created in Github.