### PR TITLE
Add package metadata for npmjs.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # AV Client Library Changelog
 
+## 0.1.10
+* Export type IAVClient
+
 ## 0.1.9
 * Added IAVClient interface for easier mocking by consumers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aion-dk/js-client",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "MIT",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@aion-dk/js-client",
   "version": "0.1.9",
+  "license": "MIT",
   "description": "Assembly Voting JS client",
   "main": "dist/lib/av_client.js",
   "types": "dist/lib/av_client.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aion-dk/js-client.git"
+  },
+  "homepage": "https://aion-dk.github.io/js-client/",
   "scripts": {
     "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/*.test.ts",
     "coverage": "tsc && nyc --reporter=json-summary --reporter=text npm run test",


### PR DESCRIPTION
Adding package metadata will show links on https://www.npmjs.com/package/@aion-dk/js-client for where source code and documentation is located.

Wrap up a release where IAVClient interface is correctly exported.