### PR TITLE
Publish to npmjs.org when a Github release is created

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: '14.x'
           cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
       - run: npm publish


### PR DESCRIPTION
This commit changes publishing to npmjs.org instead of Github's
registry.

Last two releases were published manually, this change automates the publishing step.