### PR TITLE
Updated walkthrough test with test credential for BABE

### DIFF
--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -10,7 +10,6 @@ import {
 } from './test_helpers';
 import { recordResponses } from './test_helpers'
 
-const USE_MOCK = true;
 
 describe('entire voter flow using OTP authorization', () => {
   let sandbox;
@@ -46,14 +45,14 @@ describe('entire voter flow using OTP authorization', () => {
     }
   });
 
-  it('returns a receipt', async () => {
     // For recording, remember to reset AVX database and update oneTimePassword fixture value
     // return await recordResponses(async function() {
       const client = new AVClient('http://us-avx:3000/mobile-api/us');
       await client.initialize()
 
-      const voterId = Date.now().toString().substr(0, 12);
-      await client.requestAccessCode(voterId, `us-voter-${voterId}@aion.dk`).catch((e) => {
+      const voterId = 'C01234567890' // A00000000006
+      const voterEmail = 'emersonb@spiff.com' // mvptuser@yahoo.com
+      await client.requestAccessCode(voterId, voterEmail).catch((e) => {
         console.error(e);
         expect.fail('AVClient#requestAccessCode failed.');
       });

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -52,8 +52,8 @@ describe('entire voter flow using OTP authorization', () => {
       const client = new AVClient('http://us-avx:3000/mobile-api/us');
       await client.initialize()
 
-      const voterId = 'C01234567890' // A00000000006
-      const voterEmail = 'emersonb@spiff.com' // mvptuser@yahoo.com
+      const voterId = 'A00000000006'
+      const voterEmail = 'mvptuser@yahoo.com'
       await client.requestAccessCode(voterId, voterEmail).catch((e) => {
         console.error(e);
         expect.fail('AVClient#requestAccessCode failed.');

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -10,6 +10,7 @@ import {
 } from './test_helpers';
 import { recordResponses } from './test_helpers'
 
+const USE_MOCK = true;
 
 describe('entire voter flow using OTP authorization', () => {
   let sandbox;
@@ -45,6 +46,7 @@ describe('entire voter flow using OTP authorization', () => {
     }
   });
 
+  it('returns a receipt', async () => {
     // For recording, remember to reset AVX database and update oneTimePassword fixture value
     // return await recordResponses(async function() {
       const client = new AVClient('http://us-avx:3000/mobile-api/us');

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -105,7 +105,7 @@ describe('entire voter flow using OTP authorization', () => {
       if(USE_MOCK)
         expectedNetworkRequests.forEach((mock) => mock.done());
     // });
-  });
+  }).timeout(10000);
 
   async function extractOTPFromEmail() {
     await sleep(500);


### PR DESCRIPTION
## Description
For a full integration test we should use BABE as the voter registry. This means we have to update the credentials to something that exists in their database.

## Issues
Because we use a static value as the voter credential we have to reset the AVX database after each integration test, since we only allow one vote per voter.

The timeout for testing the voting flow have been increased because it would often take longer than the default timeout of 2 seconds. 

Typical run of integration test
![image](https://user-images.githubusercontent.com/13235639/145387036-bfffd3b7-62b4-4ce1-9801-319b31f4e5a9.png)
