### PR TITLE
Affordance of static voter id by resetting AVX database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+AVX_DIRECTORY=<value of running `pwd` within AVX root directory>

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 dist
 node_modules
 package
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
         "chai": "^4.3.4",
+        "dotenv": "^10.0.0",
         "eslint": "^7.32.0",
         "eslint-plugin-promise": "^5.1.0",
         "mocha": "^9.1.3",
@@ -1607,6 +1608,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5601,6 +5611,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.788",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "chai": "^4.3.4",
+    "dotenv": "^10.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-promise": "^5.1.0",
     "mocha": "^9.1.3",

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -2,6 +2,8 @@ import { AVClient } from '../lib/av_client';
 import { expect } from 'chai';
 import axios from 'axios';
 const { execSync } = require('child_process');
+require('dotenv').config();
+import * as path from 'path';
 import nock = require('nock');
 import {
   resetDeterminism,
@@ -134,10 +136,18 @@ describe('entire voter flow using OTP authorization', () => {
   }
 
   function resetBackendData() {
+    if (!process.env['AVX_DIRECTORY']) {
+      throw new Error('Check .env.example on how to provide AVX_DIRECTORY environment variable');
+    }
+    const scriptPath = path.join(
+      process.env.AVX_DIRECTORY,
+      'db',
+      'development'
+    )
     execSync(
       './reset_us_seed.sh',
       {
-        cwd: '../avx/db/development',
+        cwd: scriptPath,
         stdio: 'inherit'
       }
     );

--- a/test/walkthrough.test.ts
+++ b/test/walkthrough.test.ts
@@ -57,8 +57,9 @@ describe('entire voter flow using OTP authorization', () => {
       const client = new AVClient('http://us-avx:3000/mobile-api/us');
       await client.initialize()
 
-      const voterId = '123456789012';
-      await client.requestAccessCode(voterId, `us-voter-${voterId}@aion.dk`).catch((e) => {
+      const voterId = 'A00000000006';
+      const voterEmail = 'mvptuser@yahoo.com';
+      await client.requestAccessCode(voterId, voterEmail).catch((e) => {
         console.error(e);
         expect.fail('AVClient#requestAccessCode failed.');
       });


### PR DESCRIPTION
Comes in pair with https://github.com/aion-dk/avx/pull/283

Walkthrough test can now be run with a static voter id. This requirement comes from us wanting to use external voter registry, for which dynamic timestamps won't work.

When running walkthrough test with actual AVX running in development mode, it will reset AVX database to have only minimal seed data for US setup.

### Changes for developers

Create a `.env` file using the directions in `.env.example`.