### PR TITLE
Change how functions are exported from aion crypto

### DIFF
--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1076,38 +1076,35 @@ function addBigNums(bn1_hex, bn2_hex) {
   return sum_hex
 }
 
-module.exports = function() {
-  return {
-    'Curve': Curve,
-    'DiscreteLogarithmProof': DiscreteLogarithmProof,
-    'DiscreteLogarithmEqualityProof': DiscreteLogarithmEqualityProof,
-    'DiscreteLogarithmMultipleProof': DiscreteLogarithmMultipleProof,
-    'ElGamalScalarCryptogram': ElGamalScalarCryptogram,
-    'ElGamalPointCryptogram': ElGamalPointCryptogram,
-    'SchnorrSignature': SchnorrSignature,
-
-    'pointEquals': pointEquals,
-    'pointToBits': pointToBits,
-    'addPoints': addPoints,
-    'pointFromBits': pointFromBits,
-    'randomBN': randomBN,
-    'randomPoint': randomPoint,
-    'recoverYfromX': recoverYfromX,
-    'hashToBn': hashToBn,
-    'VOTE_ENCODING_TYPE': VOTE_ENCODING_TYPE,
-    'voteToPoint': voteToPoint,
-    'pointToVote': pointToVote,
-    'generateKeyPair': generateKeyPair,
-    'generateSchnorrSignature': generateSchnorrSignature,
-    'verifySchnorrSignature': verifySchnorrSignature,
-    'generateRandomNumber': generateRandomNumber,
-    'generateRandomPoint': generateRandomPoint,
-    'verifyEmptyCryptogramProof': verifyEmptyCryptogramProof,
-    'encryptVote': encryptVote,
-    'encryptVotePoint': encryptVotePoint,
-    'generateDiscreteLogarithmProof': generateDiscreteLogarithmProof,
-    'orderObjectByKeys': orderObjectByKeys,
-    'hashString': hashString,
-    'addBigNums': addBigNums,
-  }
+module.exports = {
+  'Curve': Curve,
+  'DiscreteLogarithmProof': DiscreteLogarithmProof,
+  'DiscreteLogarithmEqualityProof': DiscreteLogarithmEqualityProof,
+  'DiscreteLogarithmMultipleProof': DiscreteLogarithmMultipleProof,
+  'ElGamalScalarCryptogram': ElGamalScalarCryptogram,
+  'ElGamalPointCryptogram': ElGamalPointCryptogram,
+  'SchnorrSignature': SchnorrSignature,
+  //'pointEquals': pointEquals,                             // Not used?
+  //'pointToBits': pointToBits,                             // Not used?
+  //'addPoints': addPoints,                                 // Not used?
+  'pointFromBits': pointFromBits,
+  //'randomBN': randomBN,                                   // Not used?
+  //'randomPoint': randomPoint,                             // Not used?
+  //'recoverYfromX': recoverYfromX,                         // Not used?
+  //'hashToBn': hashToBn,                                   // Not used?
+  //'VOTE_ENCODING_TYPE': VOTE_ENCODING_TYPE,               // Not used?
+  // 'voteToPoint': voteToPoint,                            // Not used?
+  // 'pointToVote': pointToVote,                            // Not used?
+  'generateKeyPair': generateKeyPair,
+  'generateSchnorrSignature': generateSchnorrSignature,
+  'verifySchnorrSignature': verifySchnorrSignature,
+  'generateRandomNumber': generateRandomNumber,
+  //'generateRandomPoint': generateRandomPoint,             // Not used?
+  'verifyEmptyCryptogramProof': verifyEmptyCryptogramProof,
+  'encryptVote': encryptVote,
+  //'encryptVotePoint': encryptVotePoint,                   // Not used?
+  'generateDiscreteLogarithmProof': generateDiscreteLogarithmProof,
+  //'orderObjectByKeys': orderObjectByKeys,                 // Not used?
+  'hashString': hashString,
+  //'addBigNums': addBigNums,                               // Not used?
 }

--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1077,17 +1077,17 @@ function addBigNums(bn1_hex, bn2_hex) {
 }
 
 module.exports = {
-  'Curve': Curve,
-  'DiscreteLogarithmProof': DiscreteLogarithmProof,
-  'DiscreteLogarithmEqualityProof': DiscreteLogarithmEqualityProof,
-  'DiscreteLogarithmMultipleProof': DiscreteLogarithmMultipleProof,
-  'ElGamalScalarCryptogram': ElGamalScalarCryptogram,
-  'ElGamalPointCryptogram': ElGamalPointCryptogram,
-  'SchnorrSignature': SchnorrSignature,
+  Curve,
+  DiscreteLogarithmProof,
+  DiscreteLogarithmEqualityProof,
+  DiscreteLogarithmMultipleProof,
+  ElGamalScalarCryptogram,
+  ElGamalPointCryptogram,
+  SchnorrSignature,
   //'pointEquals': pointEquals,                             // Not used?
   //'pointToBits': pointToBits,                             // Not used?
   //'addPoints': addPoints,                                 // Not used?
-  'pointFromBits': pointFromBits,
+  pointFromBits,
   //'randomBN': randomBN,                                   // Not used?
   //'randomPoint': randomPoint,                             // Not used?
   //'recoverYfromX': recoverYfromX,                         // Not used?
@@ -1095,16 +1095,16 @@ module.exports = {
   //'VOTE_ENCODING_TYPE': VOTE_ENCODING_TYPE,               // Not used?
   // 'voteToPoint': voteToPoint,                            // Not used?
   // 'pointToVote': pointToVote,                            // Not used?
-  'generateKeyPair': generateKeyPair,
-  'generateSchnorrSignature': generateSchnorrSignature,
-  'verifySchnorrSignature': verifySchnorrSignature,
-  'generateRandomNumber': generateRandomNumber,
+  generateKeyPair,
+  generateSchnorrSignature,
+  verifySchnorrSignature,
+  generateRandomNumber,
   //'generateRandomPoint': generateRandomPoint,             // Not used?
-  'verifyEmptyCryptogramProof': verifyEmptyCryptogramProof,
-  'encryptVote': encryptVote,
+  verifyEmptyCryptogramProof,
+  encryptVote,
   //'encryptVotePoint': encryptVotePoint,                   // Not used?
-  'generateDiscreteLogarithmProof': generateDiscreteLogarithmProof,
+  generateDiscreteLogarithmProof,
   //'orderObjectByKeys': orderObjectByKeys,                 // Not used?
-  'hashString': hashString,
+  hashString,
   //'addBigNums': addBigNums,                               // Not used?
 }

--- a/lib/av_client/encrypt_votes.ts
+++ b/lib/av_client/encrypt_votes.ts
@@ -1,6 +1,5 @@
 import { CastVoteRecord, ContestMap, OpenableEnvelope } from "./types";
-import * as crypto from './aion_crypto'
-const Crypto = crypto();
+import { encryptVote, hashString } from './aion_crypto'
 
 const encrypt = (
   contestSelections: CastVoteRecord,
@@ -11,7 +10,7 @@ const encrypt = (
   const response = {}
 
   Object.keys(contestSelections).forEach(function(contestId) {
-    const { cryptogram, randomness } = Crypto.encryptVote(
+    const { cryptogram, randomness } = encryptVote(
       contestEncodingTypes[contestId],
       contestSelections[contestId],
       emptyCryptograms[contestId],
@@ -27,7 +26,7 @@ const encrypt = (
 const fingerprint = (cryptograms: ContestMap<Cryptogram>): string => {
   const string = JSON.stringify(cryptograms)
 
-  return Crypto.hashString(string)
+  return hashString(string)
 }
 
 export default {

--- a/lib/av_client/generate_key_pair.ts
+++ b/lib/av_client/generate_key_pair.ts
@@ -1,9 +1,8 @@
 import { KeyPair } from './types';
-import * as crypto from './aion_crypto'
-const Crypto = crypto();
+import { generateKeyPair  } from './aion_crypto';
 
 export function randomKeyPair(): KeyPair {
-  const keyPair = Crypto.generateKeyPair();
+  const keyPair = generateKeyPair();
 
   return {
     privateKey: keyPair.private_key,

--- a/lib/av_client/register_voter.ts
+++ b/lib/av_client/register_voter.ts
@@ -1,7 +1,6 @@
 import { ContestMap, EmptyCryptogram, KeyPair } from "./types";
 import { BulletinBoard } from './connectors/bulletin_board';
-import * as crypto from './aion_crypto'
-const Crypto = crypto();
+import * as Crypto from './aion_crypto';
 
 interface RegisterVoterResponse {
   voterSessionUuid: string;

--- a/lib/av_client/sign.ts
+++ b/lib/av_client/sign.ts
@@ -1,7 +1,7 @@
 import { BallotBoxReceipt, ContestMap, OpenableEnvelope, SealedEnvelope } from './types'
-import * as crypto from './aion_crypto'
+import * as Crypto from './aion_crypto';
 import * as sjcl from './sjcl';
-const Crypto = crypto();
+
 
 export type AcknowledgedBoardHash = {
   currentBoardHash: string;

--- a/test/submit_ballot_cryptograms.test.ts
+++ b/test/submit_ballot_cryptograms.test.ts
@@ -8,7 +8,8 @@ import {
   OTPProviderHost,
   voterAuthorizerHost
 } from './test_helpers';
-const Crypto = require('../lib/av_client/aion_crypto.js')()
+import * as Crypto from '../lib/av_client/aion_crypto';
+
 const fs = require('fs')
 
 describe('AVClient#submitBallotCryptograms', () => {


### PR DESCRIPTION
I propose that we clean up how functions (and which) are exported from aion_crypto.

This is done to streamline how we import modules/libraries (i.e. avoid using `const .. = require()`).

* Disabled export of unused functions. Would like a discussion on what
  should happen to these (required?, deprecated? remove them?).