### PR TITLE
Pin 3rd party version of github-push-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
           git add docs
           git commit -m "Updated documentation"
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@8407731efefc0d8f72af254c74276b7a90be36e1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           fi
       - name: Push committed coverage badge
         if: success() && github.ref == 'refs/heads/main'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@8407731efefc0d8f72af254c74276b7a90be36e1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
To safe-guard against supply chain vulnerabilities, this commit pins our
usage of ad-m/github-push-action (Github Action) to a specific commit
id. This is especially important since this action receives a secret
token.