### PR TITLE
Generate and verify commitments

### DIFF
--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1084,14 +1084,14 @@ module.exports = {
   ElGamalScalarCryptogram,
   ElGamalPointCryptogram,
   SchnorrSignature,
-  //'pointEquals': pointEquals,                             // Not used?
-  //'pointToBits': pointToBits,                             // Not used?
-  //'addPoints': addPoints,                                 // Not used?
+  pointEquals,
+  pointToBits,
+  addPoints,
   pointFromBits,
-  //'randomBN': randomBN,                                   // Not used?
+  randomBN,
   //'randomPoint': randomPoint,                             // Not used?
   //'recoverYfromX': recoverYfromX,                         // Not used?
-  //'hashToBn': hashToBn,                                   // Not used?
+  hashToBn,
   //'VOTE_ENCODING_TYPE': VOTE_ENCODING_TYPE,               // Not used?
   // 'voteToPoint': voteToPoint,                            // Not used?
   // 'pointToVote': pointToVote,                            // Not used?

--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1077,6 +1077,7 @@ function addBigNums(bn1_hex, bn2_hex) {
 }
 
 const pointToHex = (point) => sjcl.codec.hex.fromBits(pointToBits(point, true));
+const hexToPoint = (hexString) => pointFromBits(sjcl.codec.hex.toBits(hexString));
 const hexToBignum = (hexString) => sjcl.bn.fromBits(sjcl.codec.hex.toBits(hexString));
 const bignumToHex = (bignum) => sjcl.codec.hex.fromBits(bignum.toBits());
 const isBignumEven = (x) => {
@@ -1116,31 +1117,46 @@ class PedersenCommitment {
       x = x.add(new sjcl.bn(1)).mod(secp256k1_curve_prime);
     }
   }
+
+  static verify(commitment, messages, randomizer) {
+    return pointEquals(commitment, this.generate(messages, randomizer));
+  }
   
   static generate(messages, randomizer) {
     let commitment = Curve.G.mult(randomizer);
   
     messages.map((message, index) => {
-      let message_bn = hexToBignum(message);
       let generator = PedersenCommitment.computeGenerator(index);
-      let term = generator.mult(message_bn);
+      let term = generator.mult(message);
   
       commitment = addPoints(commitment, term);
     });
   
-    return {
-      commitment: pointToHex(commitment),
-      randomizer: bignumToHex(randomizer)
-    };
+    return commitment;
   }
 }
 
 // Commit to cryptogram randomizer
 // Generate encryption commitment
 const generatePedersenCommitment = (messages) => {
+  const bnMessages = messages.map(m => hexToBignum(m));
   const randomizer = randomBN();
-  return PedersenCommitment.generate(messages, randomizer);
+
+  const commitment = PedersenCommitment.generate(bnMessages, randomizer);
+
+  return {
+    commitment: pointToHex(commitment),
+    randomizer: bignumToHex(randomizer),
+  }
 };
+
+const verifyPedersenCommitment = (commitment, messages, randomizer) => {
+  const pointCommitment = hexToPoint(commitment);
+  const bnMessages = messages.map(m => hexToBignum(m));
+  const bnRandomizer = hexToBignum(randomizer);
+
+  return PedersenCommitment.verify(pointCommitment, bnMessages, bnRandomizer);
+}
 
 module.exports = function() {
   return {
@@ -1153,6 +1169,7 @@ module.exports = function() {
     'SchnorrSignature': SchnorrSignature,
 
     generatePedersenCommitment,
+    verifyPedersenCommitment,
     'pointEquals': pointEquals,
     'pointToBits': pointToBits,
     'addPoints': addPoints,

--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1098,22 +1098,21 @@ const pointFromX = (x) => {
 class PedersenCommitment {
   static computeGenerator(index) {
     const baseGeneratorPrefix = () => pointToHex(Curve.G);
-  
     const secp256k1_curve_prime = Curve.field.modulus;
-  
+
     const target = [baseGeneratorPrefix(), index].join(',');
     let x = hashToBn(target).mod(secp256k1_curve_prime);
-  
+
     while(true) {
       try {
         let point = pointFromX(x);
-  
+
         return point;
       }
       catch(err) {
         // Skip to next iteration
       }
-  
+
       x = x.add(new sjcl.bn(1)).mod(secp256k1_curve_prime);
     }
   }
@@ -1121,17 +1120,17 @@ class PedersenCommitment {
   static verify(commitment, messages, randomizer) {
     return pointEquals(commitment, this.generate(messages, randomizer));
   }
-  
+
   static generate(messages, randomizer) {
     let commitment = Curve.G.mult(randomizer);
-  
-    messages.map((message, index) => {
+
+    messages.forEach((message, index) => {
       let generator = PedersenCommitment.computeGenerator(index);
       let term = generator.mult(message);
-  
+
       commitment = addPoints(commitment, term);
     });
-  
+
     return commitment;
   }
 }

--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1086,7 +1086,7 @@ const isBignumEven = (x) => {
   return (x.limbs[0] % 2) === 0;
 }
 
-function pointFromX(x) {
+const pointFromX = (x) => {
   const flag = !isBignumEven(x) ? 2 : 3;
   const flagBignum = new sjcl.bn(flag);
 
@@ -1094,46 +1094,53 @@ function pointFromX(x) {
   return pointFromBits(encodedPoint);
 }
 
-function computeGenerator(index) {
-  const baseGeneratorPrefix = () => pointToHex(Curve.G);
-
-  const secp256k1_curve_prime = Curve.field.modulus;
-
-  const target = [baseGeneratorPrefix(), index].join(',');
-  x = hashToBn(target).mod(secp256k1_curve_prime);
-
-  while(true) {
-    try {
-      let point = pointFromX(x);
-
-      return point;
+class PedersenCommitment {
+  static computeGenerator(index) {
+    const baseGeneratorPrefix = () => pointToHex(Curve.G);
+  
+    const secp256k1_curve_prime = Curve.field.modulus;
+  
+    const target = [baseGeneratorPrefix(), index].join(',');
+    let x = hashToBn(target).mod(secp256k1_curve_prime);
+  
+    while(true) {
+      try {
+        let point = pointFromX(x);
+  
+        return point;
+      }
+      catch(err) {
+        // Skip to next iteration
+      }
+  
+      x = x.add(new sjcl.bn(1)).mod(secp256k1_curve_prime);
     }
-    catch(err) {
-      console.log(err);
-    }
-
-    x = x.add(new sjcl.bn(1)).mod(secp256k1_curve_prime);
+  }
+  
+  static generate(messages, randomizer) {
+    let commitment = Curve.G.mult(randomizer);
+  
+    messages.map((message, index) => {
+      let message_bn = hexToBignum(message);
+      let generator = PedersenCommitment.computeGenerator(index);
+      let term = generator.mult(message_bn);
+  
+      commitment = addPoints(commitment, term);
+    });
+  
+    return {
+      commitment: pointToHex(commitment),
+      randomizer: bignumToHex(randomizer)
+    };
   }
 }
 
-function generatePedersenCommitment(messages) {
-  const randomizerOfCommitment = randomBN();
-
-  let commitment = Curve.G.mult(randomizerOfCommitment);
-
-  messages.map((message, index) => {
-    message_bn = hexToBignum(message);
-    generator = computeGenerator(index);
-    term = generator.mult(message_bn);
-
-    commitment = addPoints(commitment, term);
-  });
-
-  return [
-    pointToHex(commitment),
-    bignumToHex(randomizerOfCommitment)
-  ];
-}
+// Commit to cryptogram randomizer
+// Generate encryption commitment
+const generatePedersenCommitment = (messages) => {
+  const randomizer = randomBN();
+  return PedersenCommitment.generate(messages, randomizer);
+};
 
 module.exports = function() {
   return {
@@ -1145,6 +1152,7 @@ module.exports = function() {
     'ElGamalPointCryptogram': ElGamalPointCryptogram,
     'SchnorrSignature': SchnorrSignature,
 
+    generatePedersenCommitment,
     'pointEquals': pointEquals,
     'pointToBits': pointToBits,
     'addPoints': addPoints,

--- a/lib/av_client/aion_crypto.js
+++ b/lib/av_client/aion_crypto.js
@@ -1076,6 +1076,65 @@ function addBigNums(bn1_hex, bn2_hex) {
   return sum_hex
 }
 
+const pointToHex = (point) => sjcl.codec.hex.fromBits(pointToBits(point, true));
+const hexToBignum = (hexString) => sjcl.bn.fromBits(sjcl.codec.hex.toBits(hexString));
+const bignumToHex = (bignum) => sjcl.codec.hex.fromBits(bignum.toBits());
+const isBignumEven = (x) => {
+  if(!x.limbs || !x.limbs.length > 0)
+    throw new sjcl.exception.corrupt("invalid bignum");
+
+  return (x.limbs[0] % 2) === 0;
+}
+
+function pointFromX(x) {
+  const flag = !isBignumEven(x) ? 2 : 3;
+  const flagBignum = new sjcl.bn(flag);
+
+  const encodedPoint = sjcl.bitArray.concat(flagBignum.toBits(), x.toBits());
+  return pointFromBits(encodedPoint);
+}
+
+function computeGenerator(index) {
+  const baseGeneratorPrefix = () => pointToHex(Curve.G);
+
+  const secp256k1_curve_prime = Curve.field.modulus;
+
+  const target = [baseGeneratorPrefix(), index].join(',');
+  x = hashToBn(target).mod(secp256k1_curve_prime);
+
+  while(true) {
+    try {
+      let point = pointFromX(x);
+
+      return point;
+    }
+    catch(err) {
+      console.log(err);
+    }
+
+    x = x.add(new sjcl.bn(1)).mod(secp256k1_curve_prime);
+  }
+}
+
+function generatePedersenCommitment(messages) {
+  const randomizerOfCommitment = randomBN();
+
+  let commitment = Curve.G.mult(randomizerOfCommitment);
+
+  messages.map((message, index) => {
+    message_bn = hexToBignum(message);
+    generator = computeGenerator(index);
+    term = generator.mult(message_bn);
+
+    commitment = addPoints(commitment, term);
+  });
+
+  return [
+    pointToHex(commitment),
+    bignumToHex(randomizerOfCommitment)
+  ];
+}
+
 module.exports = function() {
   return {
     'Curve': Curve,
@@ -1109,5 +1168,7 @@ module.exports = function() {
     'orderObjectByKeys': orderObjectByKeys,
     'hashString': hashString,
     'addBigNums': addBigNums,
+    generatePedersenCommitment,
+    pointFromX
   }
 }

--- a/lib/av_client/crypto/bignum.ts
+++ b/lib/av_client/crypto/bignum.ts
@@ -1,5 +1,10 @@
 import * as sjcl from "../sjcl";
 
+// As this is working with untyped SJCL classes,
+// we need the _any_ type in this wrapper.
+
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
 export default class Bignum {
   private bn: any;
 

--- a/lib/av_client/crypto/bignum.ts
+++ b/lib/av_client/crypto/bignum.ts
@@ -1,0 +1,18 @@
+import * as sjcl from "../sjcl";
+
+export default class Bignum {
+  private bn: any;
+
+  constructor(data: any) {
+    this.bn = new sjcl.bn(data);
+  }
+
+  isEven = () => this.bn.limbs[0] % 2 === 0;
+  equals = (other: Bignum): boolean => !!this.bn.equals(other.bn);
+
+  mod = (operand: Bignum): Bignum => new Bignum(this.bn.mod(operand.bn));
+  add = (operand: Bignum): Bignum => new Bignum(this.bn.add(operand.bn))
+
+  toBits = () => this.bn.toBits();
+  toBn = () => this.bn;
+}

--- a/lib/av_client/crypto/bitarray.ts
+++ b/lib/av_client/crypto/bitarray.ts
@@ -1,0 +1,1 @@
+export type BitArray = unknown;

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -1,15 +1,15 @@
 import {
-  Bignum,
-  Point,
-  pointToHex,
-  pointFromHex,
-  Curve,
-  pointFromX,
-  hashToBignum,
-  bignumFromHex,
   addPoints,
-  generateRandomBignum,
+  Bignum,
+  bignumFromHex,
   bignumToHex,
+  Curve,
+  generateRandomBignum,
+  hashToBignum,
+  Point,
+  pointFromHex,
+  pointFromX,
+  pointToHex,
 } from "./util";
 
 class PedersenCommitment {

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -1,15 +1,16 @@
+import Bignum from "./bignum";
+import Point from "./point";
 import {
   addPoints,
-  Bignum,
   bignumFromHex,
   bignumToHex,
   Curve,
   generateRandomBignum,
   hashToBignum,
-  Point,
   pointFromHex,
   pointFromX,
   pointToHex,
+  isValidHexString
 } from "./util";
 
 class PedersenCommitment {
@@ -58,6 +59,9 @@ class PedersenCommitment {
  * @returns Commitment point and randomizer, both as hex.
  */
 const generatePedersenCommitment = (messages: string[], options?: { randomizer: string }) => {
+  if(messages.some(m => !isValidHexString(m)))
+    throw new Error("Input is not a valid hex string");
+
   const bnMessages: Bignum[] = messages.map(m => bignumFromHex(m));
 
   const randomizer = options && options.randomizer ?
@@ -76,6 +80,9 @@ const generatePedersenCommitment = (messages: string[], options?: { randomizer: 
  * @returns true if commitment passes validity check. Otherwise false.
  */
 const isValidPedersenCommitment = (commitment: string, messages: string[], randomizer: string) => {
+  if([...messages, commitment, randomizer].some(m => !isValidHexString(m)))
+    throw new Error("Input is not a valid hex string");
+
   const pointCommitment = pointFromHex(commitment);
   const bnMessages = messages.map(m => bignumFromHex(m));
   const bnRandomizer = bignumFromHex(randomizer);
@@ -86,4 +93,4 @@ const isValidPedersenCommitment = (commitment: string, messages: string[], rando
 export {
   generatePedersenCommitment,
   isValidPedersenCommitment,
-}
+};

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -53,6 +53,8 @@ class PedersenCommitment {
 
 /**
  * @description Generates an encryption commitment
+ * @param messages An array of hex strings
+ * @param options Optional options object. Allows caller to specify randomizer
  * @returns Commitment point and randomizer, both as hex.
  */
 const generatePedersenCommitment = (messages: string[], options?: { randomizer: string }) => {
@@ -82,7 +84,6 @@ const isValidPedersenCommitment = (commitment: string, messages: string[], rando
 }
 
 export {
-  PedersenCommitment,
   generatePedersenCommitment,
   isValidPedersenCommitment,
 }

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -14,24 +14,25 @@ import {
 } from "./util";
 
 class PedersenCommitment {
-  static computeGenerator(index) {
+  static computeGenerator(index): Point {
     const baseGeneratorPrefix = () => pointToHex(new Point(Curve.G));
     const secp256k1_curve_prime = new Bignum(Curve.field.modulus);
 
     const target = [baseGeneratorPrefix(), index].join(',');
     let x = hashToBignum(target).mod(secp256k1_curve_prime);
 
-    /*eslint no-constant-condition: ["error", { "checkLoops": false }]*/
-    while(true) {
-      try {
-        return pointFromX(x);
-      }
-      catch(err) {
-        // Skip to next iteration
-      }
+    let point: Point | null = null;
+
+    while(point === null) {
+      point = pointFromX(x);
+
+      if(point)
+        return point;
 
       x = x.add(new Bignum(1)).mod(secp256k1_curve_prime);
     }
+
+    throw new Error("Unreachable code reached");
   }
 
   static verify(commitment: Point, messages, randomizer: Bignum) {

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -1,0 +1,87 @@
+import {
+  Bignum,
+  Point,
+  pointToHex,
+  pointFromHex,
+  Curve,
+  pointFromX,
+  hashToBignum,
+  bignumFromHex,
+  addPoints,
+  generateRandomBignum,
+  bignumToHex,
+} from "./util";
+
+class PedersenCommitment {
+  static computeGenerator(index) {
+    const baseGeneratorPrefix = () => pointToHex(new Point(Curve.G));
+    const secp256k1_curve_prime = new Bignum(Curve.field.modulus);
+
+    const target = [baseGeneratorPrefix(), index].join(',');
+    let x = hashToBignum(target).mod(secp256k1_curve_prime);
+
+    while(true) {
+      try {
+        return pointFromX(x);
+      }
+      catch(err) {
+        // Skip to next iteration
+      }
+
+      x = x.add(new Bignum(1)).mod(secp256k1_curve_prime);
+    }
+  }
+
+  static verify(commitment: Point, messages, randomizer: Bignum) {
+    return commitment.equals(this.generate(messages, randomizer))
+  }
+
+  static generate(messages: Bignum[], randomizer: Bignum): Point {
+    let commitment = new Point(Curve.G).mult(randomizer);
+
+    messages.forEach((message, index) => {
+      let generator = PedersenCommitment.computeGenerator(index);
+      let term = generator.mult(message);
+
+      commitment = addPoints(commitment, term);
+    });
+
+    return commitment;
+  }
+}
+
+/**
+ * @description Generates an encryption commitment
+ * @returns Commitment point and randomizer, both as hex.
+ */
+const generatePedersenCommitment = (messages: string[], options?: { randomizer: string }) => {
+  const bnMessages: Bignum[] = messages.map(m => bignumFromHex(m));
+
+  const randomizer = options && options.randomizer ?
+    new Bignum(options.randomizer) : generateRandomBignum();
+
+  const commitment = PedersenCommitment.generate(bnMessages, randomizer);
+
+  return {
+    commitment: pointToHex(commitment),
+    randomizer: bignumToHex(randomizer),
+  }
+};
+
+/**
+ * @description Checks if a commitment is valid, given a set of messages and a randomizer
+ * @returns true if commitment passes validity check. Otherwise false.
+ */
+const isValidPedersenCommitment = (commitment: string, messages: string[], randomizer: string) => {  
+  const pointCommitment = pointFromHex(commitment);
+  const bnMessages = messages.map(m => bignumFromHex(m));
+  const bnRandomizer = bignumFromHex(randomizer);
+
+  return PedersenCommitment.verify(pointCommitment, bnMessages, bnRandomizer);
+}
+
+export {
+  PedersenCommitment,
+  generatePedersenCommitment,
+  isValidPedersenCommitment,
+}

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -14,7 +14,7 @@ import {
 } from "./util";
 
 class PedersenCommitment {
-  static computeGenerator(index): Point {
+  static computeGenerator(index: number): Point {
     const baseGeneratorPrefix = () => pointToHex(new Point(Curve.G));
     const secp256k1_curve_prime = new Bignum(Curve.field.modulus);
 

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -20,6 +20,7 @@ class PedersenCommitment {
     const target = [baseGeneratorPrefix(), index].join(',');
     let x = hashToBignum(target).mod(secp256k1_curve_prime);
 
+    /*eslint no-constant-condition: ["error", { "checkLoops": false }]*/
     while(true) {
       try {
         return pointFromX(x);
@@ -40,8 +41,8 @@ class PedersenCommitment {
     let commitment = new Point(Curve.G).mult(randomizer);
 
     messages.forEach((message, index) => {
-      let generator = PedersenCommitment.computeGenerator(index);
-      let term = generator.mult(message);
+      const generator = PedersenCommitment.computeGenerator(index);
+      const term = generator.mult(message);
 
       commitment = addPoints(commitment, term);
     });

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -29,6 +29,7 @@ class PedersenCommitment {
       if(point)
         return point;
 
+      // No point was found for x. Attempt x+1
       x = x.add(new Bignum(1)).mod(secp256k1_curve_prime);
     }
 

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -75,7 +75,7 @@ const generatePedersenCommitment = (messages: string[], options?: { randomizer: 
  * @description Checks if a commitment is valid, given a set of messages and a randomizer
  * @returns true if commitment passes validity check. Otherwise false.
  */
-const isValidPedersenCommitment = (commitment: string, messages: string[], randomizer: string) => {  
+const isValidPedersenCommitment = (commitment: string, messages: string[], randomizer: string) => {
   const pointCommitment = pointFromHex(commitment);
   const bnMessages = messages.map(m => bignumFromHex(m));
   const bnRandomizer = bignumFromHex(randomizer);

--- a/lib/av_client/crypto/pedersen_commitment.ts
+++ b/lib/av_client/crypto/pedersen_commitment.ts
@@ -40,14 +40,14 @@ class PedersenCommitment {
   }
 
   static generate(messages: Bignum[], randomizer: Bignum): Point {
-    let commitment = new Point(Curve.G).mult(randomizer);
+    const initialPoint = new Point(Curve.G).mult(randomizer);
 
-    messages.forEach((message, index) => {
+    const commitment = messages.reduce((acc, message, index) => {
       const generator = PedersenCommitment.computeGenerator(index);
       const term = generator.mult(message);
 
-      commitment = addPoints(commitment, term);
-    });
+      return addPoints(acc, term);
+    }, initialPoint);
 
     return commitment;
   }

--- a/lib/av_client/crypto/point.ts
+++ b/lib/av_client/crypto/point.ts
@@ -1,0 +1,18 @@
+import * as crypto from "../aion_crypto";
+import Bignum from "./bignum";
+import type { BitArray } from "./bitarray";
+
+export default class Point {
+  private eccPoint: any;
+
+  constructor(point: any) {
+    this.eccPoint = point;
+  }
+
+  equals = (other: Point) => !!crypto.pointEquals(this.eccPoint, other.eccPoint);
+
+  mult = (k: Bignum): Point => new Point(this.eccPoint.mult(k.toBn()));
+
+  toBits = (compressed: boolean): BitArray => crypto.pointToBits(this.eccPoint, compressed);
+  toEccPoint = () => this.eccPoint;
+}

--- a/lib/av_client/crypto/point.ts
+++ b/lib/av_client/crypto/point.ts
@@ -2,6 +2,11 @@ import * as crypto from "../aion_crypto";
 import Bignum from "./bignum";
 import type { BitArray } from "./bitarray";
 
+// As this is working with untyped SJCL classes,
+// we need the _any_ type in this wrapper.
+
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
 export default class Point {
   private eccPoint: any;
 

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -1,16 +1,12 @@
 import * as crypto from "../aion_crypto";
-const sjcl = require('../sjcl');
+import * as sjcl from "../sjcl";
+
+// As this is working with untyped SJCL classes,
+// we need the _any_ type in this wrapper.
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
 
 export const Curve = crypto.Curve;
-
-export const addPoints = (a: Point, b: Point): Point => {
-  return new Point(crypto.addPoints(a.toEccPoint(), b.toEccPoint()));
-}
-
-export const generateRandomBignum = () => new Bignum(crypto.randomBN());
-
-export const hashToBignum = (hash: BitArray): Bignum => new Bignum(crypto.hashToBn(hash));
-
 
 // Converter functions
 // --------------------------
@@ -22,9 +18,12 @@ export const pointToHex = (point: Point): string => sjcl.codec.hex.fromBits(poin
 export const bignumFromHex = (hex: string): Bignum => new Bignum(sjcl.bn.fromBits(sjcl.codec.hex.toBits(hex)));
 export const bignumToHex = (bignum: Bignum): string => sjcl.codec.hex.fromBits(bignum.toBits());
 
+export const hashToBignum = (hash: BitArray): Bignum => new Bignum(crypto.hashToBn(hash));
 
 // Other
 // --------------------------
+export const generateRandomBignum = () => new Bignum(crypto.randomBN());
+
 export const pointFromX = (x: Bignum): Point => {
   const flag = !x.isEven() ? 2 : 3;
   const flagBignum = new sjcl.bn(flag);
@@ -34,10 +33,14 @@ export const pointFromX = (x: Bignum): Point => {
   return new Point(pointFromBits(encodedPoint));
 }
 
+export const addPoints = (a: Point, b: Point): Point => {
+  return new Point(crypto.addPoints(a.toEccPoint(), b.toEccPoint()));
+}
+
 // Types
 // --------------------------
 export class Bignum {
-  private bn: any;
+  private bn: any; 
 
   constructor(data: any) {
     this.bn = new sjcl.bn(data);
@@ -69,4 +72,4 @@ export class Point {
   toEccPoint = () => this.eccPoint;
 }
 
-type BitArray = {}
+type BitArray = unknown;

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -4,10 +4,6 @@ import Bignum from "./bignum";
 import Point from "./point";
 import type { BitArray } from "./bitarray";
 
-// As this is working with untyped SJCL classes,
-// we need the _any_ type in this wrapper.
-/*eslint-disable @typescript-eslint/no-explicit-any*/
-
 export const Curve = crypto.Curve;
 
 // Converter functions

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -40,7 +40,7 @@ export const addPoints = (a: Point, b: Point): Point => {
 // Types
 // --------------------------
 export class Bignum {
-  private bn: any; 
+  private bn: any;
 
   constructor(data: any) {
     this.bn = new sjcl.bn(data);

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -22,13 +22,21 @@ export const hashToBignum = (hash: BitArray): Bignum => new Bignum(crypto.hashTo
 // --------------------------
 export const generateRandomBignum = () => new Bignum(crypto.randomBN());
 
-export const pointFromX = (x: Bignum): Point => {
+export const pointFromX = (x: Bignum): Point | null => {
   const flag = !x.isEven() ? 2 : 3;
   const flagBignum = new sjcl.bn(flag);
 
   const encodedPoint = sjcl.bitArray.concat(flagBignum.toBits(), x.toBits());
 
-  return new Point(pointFromBits(encodedPoint));
+  try {
+    return new Point(pointFromBits(encodedPoint));
+  } catch(err) {
+    if(err instanceof sjcl.exception.corrupt) {
+      return null;
+    }
+
+    throw err;
+  }
 }
 
 export const addPoints = (a: Point, b: Point): Point => {

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -22,6 +22,12 @@ export const hashToBignum = (hash: BitArray): Bignum => new Bignum(crypto.hashTo
 // --------------------------
 export const generateRandomBignum = () => new Bignum(crypto.randomBN());
 
+
+/**
+ *
+ * @param x x-value from with to derive y-value on the elliptic curve
+ * @returns A valid point, if one exists for x. Otherwise null
+ */
 export const pointFromX = (x: Bignum): Point | null => {
   const flag = !x.isEven() ? 2 : 3;
   const flagBignum = new sjcl.bn(flag);

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -1,0 +1,72 @@
+import * as crypto from "../aion_crypto";
+const sjcl = require('../sjcl');
+
+export const Curve = crypto.Curve;
+
+export const addPoints = (a: Point, b: Point): Point => {
+  return new Point(crypto.addPoints(a.toEccPoint(), b.toEccPoint()));
+}
+
+export const generateRandomBignum = () => new Bignum(crypto.randomBN());
+
+export const hashToBignum = (hash: BitArray): Bignum => new Bignum(crypto.hashToBn(hash));
+
+
+// Converter functions
+// --------------------------
+export const pointFromBits = (bits) => crypto.pointFromBits(bits);
+
+export const pointFromHex = (hex: string): Point => new Point(pointFromBits(sjcl.codec.hex.toBits(hex)));
+export const pointToHex = (point: Point): string => sjcl.codec.hex.fromBits(point.toBits(true));
+
+export const bignumFromHex = (hex: string): Bignum => new Bignum(sjcl.bn.fromBits(sjcl.codec.hex.toBits(hex)));
+export const bignumToHex = (bignum: Bignum): string => sjcl.codec.hex.fromBits(bignum.toBits());
+
+
+// Other
+// --------------------------
+export const pointFromX = (x: Bignum): Point => {
+  const flag = !x.isEven() ? 2 : 3;
+  const flagBignum = new sjcl.bn(flag);
+
+  const encodedPoint = sjcl.bitArray.concat(flagBignum.toBits(), x.toBits());
+
+  return new Point(pointFromBits(encodedPoint));
+}
+
+// Types
+// --------------------------
+export class Bignum {
+  private bn: any;
+
+  constructor(data: any) {
+    this.bn = new sjcl.bn(data);
+  }
+
+  isEven = () => this.bn.limbs[0] % 2 === 0;
+  equals = (other: Bignum): boolean => !!this.bn.equals(other.bn);
+
+  mod = (operand: Bignum): Bignum => new Bignum(this.bn.mod(operand.bn));
+  add = (operand: Bignum): Bignum => new Bignum(this.bn.add(operand.bn))
+
+  toBits = () => this.bn.toBits();
+  toBn = () => this.bn;
+}
+
+
+export class Point {
+  private eccPoint: any;
+
+  constructor(point: any) {
+    this.eccPoint = point;
+  }
+
+  equals = (other: Point) => !!crypto.pointEquals(this.eccPoint, other.eccPoint);
+
+  mult = (k: Bignum): Point => new Point(this.eccPoint.mult(k.toBn()));
+
+  toBits = (compressed: boolean): BitArray => crypto.pointToBits(this.eccPoint, compressed);
+  toEccPoint = () => this.eccPoint;
+}
+
+type BitArray = {}

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -1,10 +1,12 @@
 import * as crypto from "../aion_crypto";
 import * as sjcl from "../sjcl";
+import Bignum from "./bignum";
+import Point from "./point";
+import type { BitArray } from "./bitarray";
 
 // As this is working with untyped SJCL classes,
 // we need the _any_ type in this wrapper.
 /*eslint-disable @typescript-eslint/no-explicit-any*/
-
 
 export const Curve = crypto.Curve;
 
@@ -37,39 +39,9 @@ export const addPoints = (a: Point, b: Point): Point => {
   return new Point(crypto.addPoints(a.toEccPoint(), b.toEccPoint()));
 }
 
-// Types
-// --------------------------
-export class Bignum {
-  private bn: any;
+export const isValidHexString = (test: string): boolean => {
+  if(test.length % 2 !== 0)
+    return false;   // Hex string must be even length
 
-  constructor(data: any) {
-    this.bn = new sjcl.bn(data);
-  }
-
-  isEven = () => this.bn.limbs[0] % 2 === 0;
-  equals = (other: Bignum): boolean => !!this.bn.equals(other.bn);
-
-  mod = (operand: Bignum): Bignum => new Bignum(this.bn.mod(operand.bn));
-  add = (operand: Bignum): Bignum => new Bignum(this.bn.add(operand.bn))
-
-  toBits = () => this.bn.toBits();
-  toBn = () => this.bn;
+  return test.match(/^[0-9A-Fa-f]+$/) !== null;
 }
-
-
-export class Point {
-  private eccPoint: any;
-
-  constructor(point: any) {
-    this.eccPoint = point;
-  }
-
-  equals = (other: Point) => !!crypto.pointEquals(this.eccPoint, other.eccPoint);
-
-  mult = (k: Bignum): Point => new Point(this.eccPoint.mult(k.toBn()));
-
-  toBits = (compressed: boolean): BitArray => crypto.pointToBits(this.eccPoint, compressed);
-  toEccPoint = () => this.eccPoint;
-}
-
-type BitArray = unknown;

--- a/lib/av_client/crypto/util.ts
+++ b/lib/av_client/crypto/util.ts
@@ -32,7 +32,7 @@ export const pointFromX = (x: Bignum): Point | null => {
     return new Point(pointFromBits(encodedPoint));
   } catch(err) {
     if(err instanceof sjcl.exception.corrupt) {
-      return null;
+      return null;    // No point found on the curve
     }
 
     throw err;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "homepage": "https://aion-dk.github.io/js-client/",
   "scripts": {
-    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/**/*.test.ts",
-    "coverage": "tsc && nyc --reporter=json-summary --reporter=text npm run test",
+    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/*.test.ts ./test/**/*.test.ts",
+    "coverage": "tsc && nyc --reporter=html --reporter=text npm run test",
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --plugin none --out docs --includes test/",
     "build": "tsc && cp lib/av_client/*.js dist/lib/av_client",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://aion-dk.github.io/js-client/",
   "scripts": {
     "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/*.test.ts ./test/**/*.test.ts",
-    "coverage": "tsc && nyc --reporter=html --reporter=text npm run test",
+    "coverage": "tsc && nyc --reporter=json-summary --reporter=text npm run test",
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --plugin none --out docs --includes test/",
     "build": "tsc && cp lib/av_client/*.js dist/lib/av_client",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://aion-dk.github.io/js-client/",
   "scripts": {
-    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/*.test.ts",
+    "test": "mocha --require ts-node/register/transpile-only --require source-map-support/register --recursive --extension ts ./test/**/*.test.ts",
     "coverage": "tsc && nyc --reporter=json-summary --reporter=text npm run test",
     "tdd": "mocha --require ts-node/register/transpile-only --require source-map-support/register --extension ts ./test/**/*.test.ts --watch --watch-files test/**/*.ts,lib/**/*.ts",
     "docs": "typedoc --plugin none --out docs --includes test/",

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -10,7 +10,7 @@ describe("Pedersen Commitments", () => {
 
     expect(result.commitment).to.eq("021600f61b9d347e249b4a2d08b95458ba8e17504b5481d04165cd492cadf242fc");
     expect(result.randomizer).to.eq("01");
-    
+
     const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
     expect(isValid).to.be.true;
   })
@@ -23,7 +23,7 @@ describe("Pedersen Commitments", () => {
 
     expect(result.commitment).to.eq("02c62f4fb334f5a43d96a9c3b652cf7c930922f1627ef29349fcb2085d2f2f9aed");
     expect(result.randomizer).to.eq("01");
-    
+
     const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
     expect(isValid).to.be.true;
   });
@@ -36,7 +36,7 @@ describe("Pedersen Commitments", () => {
 
     expect(result.commitment).to.eq("027c5c17a18f5e671a9c9f09b90fa69bb8fcb52a753d8a69959cd329fe7570f366");
     expect(result.randomizer).to.eq("d05bc90d9108d486835030e1374bcef4a73dc456888444f6b16aeffbc6b32391");
-    
+
     const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
     expect(isValid).to.be.true;
   });

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -70,6 +70,10 @@ describe("Pedersen Commitments", () => {
     expect(isValid).to.be.true;
   });
 
+  it("fail validity check on invalid commitment", () => {
+    expect(() => isValidPedersenCommitment("ABCD", ["ABCD1234"], "123456")).to.throw("not on the curve!");
+  });
+
   it("fail on generation for non-hex messages", () => {
     expect(() => generatePedersenCommitment(["XYZ"])).to.throw(Error, "Input is not a valid hex string");
     expect(() => generatePedersenCommitment(["A"])).to.throw(Error, "Input is not a valid hex string");

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -43,9 +43,10 @@ describe("Pedersen Commitments", () => {
 
   it("generate commitment using built-in randomizer", () => {
     const messages = [
-      "d70d319fd1c7867af1ca477878d381e4",
-      "ef5b373b279ed26cf774d7e3376ac549",
-      "3c2e2bdcc29734c7e06d53b37cc2724c"
+      "d70d319fd1c7867af1ca477878d381e4d70d319fd1c7867af1ca477878d381e4",
+      "ef5b373b279ed26cf774d7e3376ac549ef5b373b279ed26cf774d7e3376ac549",
+      "3c2e2bdcc29734c7e06d53b37cc2724c3c2e2bdcc29734c7e06d53b37cc2724c",
+      "000000dcc29734c7e06d53b37cc2724c000000dcc29734c7e06d53b37cc2724c"
     ];
 
     const result = generatePedersenCommitment(messages);

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -91,7 +91,7 @@ describe("Pedersen Commitments", () => {
     expect(result.commitment).to.eq("03c1bb8d0986b1ce0c28d4df6e3e339c813873e03df1d4bab1a7140690674e45ca");
   });
 
-  it("fail validity check on invalid commitment", () => {
+  it("fail validity check on invalid commitment (not a point on the curve)", () => {
     expect(() => isValidPedersenCommitment("ABCD", ["ABCD1234"], "123456")).to.throw("not on the curve!");
   });
 

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -73,7 +73,6 @@ describe("Pedersen Commitments", () => {
   it("fail on generation for non-hex messages", () => {
     expect(() => generatePedersenCommitment(["XYZ"])).to.throw(Error, "Input is not a valid hex string");
     expect(() => generatePedersenCommitment(["A"])).to.throw(Error, "Input is not a valid hex string");
-
   });
 
   it("fail on validation for non-hex messages", () => {

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -52,4 +52,34 @@ describe("Pedersen Commitments", () => {
     const isValid = isValidPedersenCommitment(result.commitment, messages, result.randomizer)
     expect(isValid).to.be.true;
   });
+
+  it("generator/verifier ignores casing of messages", () => {
+    const lowerCaseMessages = [ "d70d319fd1c7867af1ca477878d381e4" ];
+    const upperCaseMessages = lowerCaseMessages.map(m => m.toUpperCase());
+
+    const result = generatePedersenCommitment(lowerCaseMessages);
+    const isValid = isValidPedersenCommitment(result.commitment, upperCaseMessages, result.randomizer)
+    expect(isValid).to.be.true;
+  });
+
+  it("generate commitment for empty set of messages", () => {
+    const messages = [];
+
+    const result = generatePedersenCommitment(messages);
+    const isValid = isValidPedersenCommitment(result.commitment, messages, result.randomizer)
+    expect(isValid).to.be.true;
+  });
+
+  it("fail on generation for non-hex messages", () => {
+    expect(() => generatePedersenCommitment(["XYZ"])).to.throw(Error, "Input is not a valid hex string");
+    expect(() => generatePedersenCommitment(["A"])).to.throw(Error, "Input is not a valid hex string");
+
+  });
+
+  it("fail on validation for non-hex messages", () => {
+    expect(() => isValidPedersenCommitment("", ["XYZ"], "")).to.throw(Error, "Input is not a valid hex string");
+    expect(() => isValidPedersenCommitment("XX", ["AA"], "")).to.throw(Error, "Input is not a valid hex string");
+    expect(() => isValidPedersenCommitment("AA", ["AA"], "XX")).to.throw(Error, "Input is not a valid hex string");
+    expect(() => isValidPedersenCommitment("A", ["AA"], "AA")).to.throw(Error, "Input is not a valid hex string");
+  });
 });

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -71,7 +71,7 @@ describe("Pedersen Commitments", () => {
     expect(isValid).to.be.true;
   });
 
-  it.only("backend counterparty test", () => {
+  it("Ensure generated commitment is identical to one generated on the backed", () => {
     const messages = ["60555da4264ac93be14a57ac8eb8a9721479955b62fb9fc9bc0e2148204734be",
     "49087997fbb2bf9b9f6a960dbefcf10197aae7662be851353665a5769afd5fc7",
     "78b1ae220fc1d8189d07ffd51afe3eeb9b3d9f9930eedea36966fdd8aa239969",

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { generatePedersenCommitment, isValidPedersenCommitment } from "../../lib/av_client/crypto/pedersen_commitment";
+
+describe("Pedersen Commitments", () => {
+  it("generate commitment from single message", () => {
+    const randomizer = "01";
+    const messages = ["ABBA"];
+
+    const result = generatePedersenCommitment(messages, { randomizer });
+
+    expect(result.commitment).to.eq("021600f61b9d347e249b4a2d08b95458ba8e17504b5481d04165cd492cadf242fc");
+    expect(result.randomizer).to.eq("01");
+    
+    const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
+    expect(isValid).to.be.true;
+  })
+
+  it("generate commitment from multiple messages", () => {
+    const randomizer = "01";
+    const messages = ["ABBA", "BEEF"];
+
+    const result = generatePedersenCommitment(messages, { randomizer });
+
+    expect(result.commitment).to.eq("02c62f4fb334f5a43d96a9c3b652cf7c930922f1627ef29349fcb2085d2f2f9aed");
+    expect(result.randomizer).to.eq("01");
+    
+    const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
+    expect(isValid).to.be.true;
+  });
+
+  it("generate commitment with realistic randomizer", () => {
+    const randomizer = "d05bc90d9108d486835030e1374bcef4a73dc456888444f6b16aeffbc6b32391";
+    const messages = ["ABBA", "BEEF", "DEADBEAF1234567890FFFFFF"];
+
+    const result = generatePedersenCommitment(messages, { randomizer });
+
+    expect(result.commitment).to.eq("027c5c17a18f5e671a9c9f09b90fa69bb8fcb52a753d8a69959cd329fe7570f366");
+    expect(result.randomizer).to.eq("d05bc90d9108d486835030e1374bcef4a73dc456888444f6b16aeffbc6b32391");
+    
+    const isValid = isValidPedersenCommitment(result.commitment, messages, randomizer)
+    expect(isValid).to.be.true;
+  });
+
+  it("generate commitment using built-in randomizer", () => {
+    const messages = [
+      "d70d319fd1c7867af1ca477878d381e4",
+      "ef5b373b279ed26cf774d7e3376ac549",
+      "3c2e2bdcc29734c7e06d53b37cc2724c"
+    ];
+
+    const result = generatePedersenCommitment(messages);
+    const isValid = isValidPedersenCommitment(result.commitment, messages, result.randomizer)
+    expect(isValid).to.be.true;
+  });
+});

--- a/test/crypto/commitment.test.ts
+++ b/test/crypto/commitment.test.ts
@@ -71,6 +71,26 @@ describe("Pedersen Commitments", () => {
     expect(isValid).to.be.true;
   });
 
+  it.only("backend counterparty test", () => {
+    const messages = ["60555da4264ac93be14a57ac8eb8a9721479955b62fb9fc9bc0e2148204734be",
+    "49087997fbb2bf9b9f6a960dbefcf10197aae7662be851353665a5769afd5fc7",
+    "78b1ae220fc1d8189d07ffd51afe3eeb9b3d9f9930eedea36966fdd8aa239969",
+    "d9492309709b97fa9278b8b00ec00e08744e07549570d0951da17c97cad72a12",
+    "6c984df612c2be71043125ce7657170772e66fcb0c54bf5ba1f7ee10537e46bc",
+    "207e5e08b7aa49ce664c107a16def239c0fedd85266364fc0513b4785d975a62",
+    "e5f87812e630bd4512300fab740cb2d0ed0d9df1ecbd2189df6dc86b2a4ded63",
+    "7cd5768b2f178bf82a6a805a86c1079d048a5da414fb37fddaf28995db233e78",
+    "550ad30e4bc121c6d20eb680b0f9b09b0d9fcf4500be9d92ac82a54790d80e57",
+    "343366aadf06230a43cbee0872a711129940fcb0ab0016383a4006deaa4b82e0"];
+
+    const randomizer = "e05f475e8c19504301735c8411541dee2d5f154e51c99d080ddd0278ec27ea05";
+
+    const result = generatePedersenCommitment(messages, { randomizer });
+    const isValid = isValidPedersenCommitment(result.commitment, messages, result.randomizer)
+    expect(isValid).to.be.true;
+    expect(result.commitment).to.eq("03c1bb8d0986b1ce0c28d4df6e3e339c813873e03df1d4bab1a7140690674e45ca");
+  });
+
   it("fail validity check on invalid commitment", () => {
     expect(() => isValidPedersenCommitment("ABCD", ["ABCD1234"], "123456")).to.throw("not on the curve!");
   });


### PR DESCRIPTION
Adds generation and verification of encryption commitments.

As part of the discussion on how to turn aion_crypto into a tested, standalone, high quality library this PRs proposes to start splitting things into smaller separate modules, and using static typing (typescript).

As the underlying crypto implementation (SJCL) uses untyped JS classes, this PR introduces typed wrapper classes for Point and Bignum.

* Written in typescript, and using a typescript wrapper of aion_crypto lib.
* Added unit tests for generator & verifier functions.
* Validated against commitment generator implementation in the backend