### PR TITLE
Fix ContestConfig and BallotConfig type

### DIFF
--- a/lib/av_client/cvr_conversion.ts
+++ b/lib/av_client/cvr_conversion.ts
@@ -1,12 +1,12 @@
 import {
-  ContestConfig,
+  ContestConfigMap,
   CastVoteRecord,
   ContestMap,
 } from './types';
 
 import { flattenOptions } from './flatten_options'
 
-export function cvrToCodes(contestConfigs: ContestConfig, cvr: CastVoteRecord){
+export function cvrToCodes(contestConfigs: ContestConfigMap, cvr: CastVoteRecord){
   const cvrCodes = {}
   Object.keys(cvr).forEach(contestId => {
     const flatOptions = flattenOptions(contestConfigs[contestId].options)
@@ -17,7 +17,7 @@ export function cvrToCodes(contestConfigs: ContestConfig, cvr: CastVoteRecord){
   return cvrCodes
 }
 
-export function codesToCvr(contestConfigs: ContestConfig, cvrCodes: ContestMap<number>){
+export function codesToCvr(contestConfigs: ContestConfigMap, cvrCodes: ContestMap<number>){
   const cvr = {}
   Object.keys(cvrCodes).forEach(contestId => {
     const flatOptions = flattenOptions(contestConfigs[contestId].options)

--- a/lib/av_client/cvr_validation.ts
+++ b/lib/av_client/cvr_validation.ts
@@ -1,4 +1,4 @@
-import { BallotConfig, CastVoteRecord, ContestConfigMap } from './types';
+import { BallotConfigMap, CastVoteRecord, ContestConfigMap } from './types';
 import { flattenOptions } from './flatten_options'
 
 type ValidationResult = ':okay'
@@ -9,7 +9,7 @@ type ValidationResult = ':okay'
 const validateCvr = (
   cvr: CastVoteRecord,
   voterGroup: string,
-  ballotConfigs: BallotConfig,
+  ballotConfigs: BallotConfigMap,
   allContests: ContestConfigMap) : ValidationResult => {
 
   const ballotConfig = ballotConfigs[voterGroup];

--- a/lib/av_client/cvr_validation.ts
+++ b/lib/av_client/cvr_validation.ts
@@ -1,4 +1,4 @@
-import { BallotConfig, CastVoteRecord, ContestConfig } from './types';
+import { BallotConfig, CastVoteRecord, ContestConfigMap } from './types';
 import { flattenOptions } from './flatten_options'
 
 type ValidationResult = ':okay'
@@ -10,7 +10,7 @@ const validateCvr = (
   cvr: CastVoteRecord,
   voterGroup: string,
   ballotConfigs: BallotConfig,
-  allContests: ContestConfig) : ValidationResult => {
+  allContests: ContestConfigMap) : ValidationResult => {
 
   const ballotConfig = ballotConfigs[voterGroup];
 

--- a/lib/av_client/decrypt_vote.ts
+++ b/lib/av_client/decrypt_vote.ts
@@ -1,10 +1,10 @@
-import { CastVoteRecord, ContestConfig, CommitmentOpening, ContestMap, MarkingType } from "./types";
+import { CastVoteRecord, ContestConfigMap, CommitmentOpening, ContestMap, MarkingType } from "./types";
 import { decryptVote } from './crypto/decrypt_vote';
 import { codesToCvr } from './cvr_conversion';
 import { addBigNums } from './aion_crypto';
 
 export const decrypt = (
-  contestConfigs: ContestConfig,
+  contestConfigs: ContestConfigMap,
   markingType: MarkingType,
   encryptionKey: string,
   cryptograms: ContestMap<string[]>, 

--- a/lib/av_client/eligibility_check.ts
+++ b/lib/av_client/eligibility_check.ts
@@ -1,9 +1,9 @@
-import { BallotConfig, CastVoteRecord } from "./types";
+import { BallotConfigMap, CastVoteRecord } from "./types";
 
 export const checkEligibility = (
   voterGroup: string,
   cvr: CastVoteRecord,
-  ballotConfigs: BallotConfig
+  ballotConfigs: BallotConfigMap
 ): ":okay" | ":not_eligible" => {
 
   const voterGroupConfig = ballotConfigs[voterGroup];

--- a/lib/av_client/encrypt_votes.ts
+++ b/lib/av_client/encrypt_votes.ts
@@ -1,11 +1,11 @@
-import { CastVoteRecord, ContestConfig, ContestMap, MarkingType, OpenableEnvelope } from "./types";
+import { CastVoteRecord, ContestConfigMap, ContestMap, MarkingType, OpenableEnvelope } from "./types";
 import { encryptVote } from './crypto/encrypt_vote';
 import { cvrToCodes } from './cvr_conversion';
 import { hashString, ElGamalPointCryptogram } from './aion_crypto';
 import {Uniformer} from "../util/uniformer";
 
 const encrypt = (
-  contestConfigs: ContestConfig,
+  contestConfigs: ContestConfigMap,
   contestSelections: CastVoteRecord,
   markingType: MarkingType,
   encryptionKey: string): ContestMap<OpenableEnvelope> => {

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -241,7 +241,7 @@ export type BallotConfig = {
   }
 };
 
-export type ContestConfig = {
+export type ContestConfigMap = {
   [contestReference: string]: {
     options: Option[]
     markingType: MarkingType
@@ -272,7 +272,7 @@ export interface ElectionConfig {
 
   dbbPublicKey: string
 
-  contestConfigs: ContestConfig
+  contestConfigs: ContestConfigMap
   ballotConfigs: BallotConfig;
 
   // appended data:

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -236,10 +236,13 @@ export type Signature = string;
 export type HashValue = string;
 
 export type BallotConfigMap = {
-  [voterGroupId: string]: {
-    contestReferences: string[]
-  }
+  [voterGroupId: string]: BallotConfig
 };
+
+export type BallotConfig = {
+  voterGroup: string
+  contestReferences: string[]
+}
 
 export type ContestConfigMap = {
   [contestReference: string]: ContestConfig

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -235,7 +235,7 @@ export interface ClientState {
 export type Signature = string;
 export type HashValue = string;
 
-export type BallotConfig = {
+export type BallotConfigMap = {
   [voterGroupId: string]: {
     contestReferences: string[]
   }
@@ -273,7 +273,7 @@ export interface ElectionConfig {
   dbbPublicKey: string
 
   contestConfigs: ContestConfigMap
-  ballotConfigs: BallotConfig;
+  ballotConfigs: BallotConfigMap;
 
   // appended data:
   affidavit: AffidavitConfig;

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -242,16 +242,19 @@ export type BallotConfigMap = {
 };
 
 export type ContestConfigMap = {
-  [contestReference: string]: {
-    options: Option[]
-    markingType: MarkingType
-    resultType: {
-      name: string
-    }
-    title: LocalString
-    subtitle: LocalString
-    description: LocalString
+  [contestReference: string]: ContestConfig
+}
+
+export type ContestConfig = {
+  reference: string
+  options: Option[]
+  markingType: MarkingType
+  resultType: {
+    name: string
   }
+  title: LocalString
+  subtitle: LocalString
+  description: LocalString
 }
 
 export type MarkingType = {

--- a/test/cvr_validation.test.ts
+++ b/test/cvr_validation.test.ts
@@ -37,6 +37,7 @@ describe('validateCvr', () => {
 
       const ballotConfigs = {
         [VOTER_GROUP]: {
+          voterGroup: VOTER_GROUP,
           contestReferences: [ "a", "b" ]
         }
       };

--- a/test/cvr_validation.test.ts
+++ b/test/cvr_validation.test.ts
@@ -22,9 +22,9 @@ const template = {
 describe('validateCvr', () => {
   context('given invalid CVR', () => {
     it('fails when voting on invalid contests or invalid options', async () => {
-      const contest1 = { ...template, options: createOptions(['1', '2']) };
-      const contest2 = { ...template, options: createOptions(['3', '4']) };
-      const contest3 = { ...template, options: createOptions(['5', '6']) };
+      const contest1 = { ...template, reference: 'a', options: createOptions(['1', '2']) };
+      const contest2 = { ...template, reference: 'b', options: createOptions(['3', '4']) };
+      const contest3 = { ...template, reference: 'c', options: createOptions(['5', '6']) };
 
       const allContests = {a: contest1, b: contest2, c: contest3 };
 

--- a/test/eligibility_check.test.ts
+++ b/test/eligibility_check.test.ts
@@ -7,8 +7,8 @@ describe('Eligibility Check', () => {
       const voterGroup = "4";
 
       const ballotConfigs = {
-        "4": { contestReferences: ['a', 'b'] },
-        "5": { contestReferences: ['c', 'd'] }
+        "4": { voterGroup: "4", contestReferences: ['a', 'b'] },
+        "5": { voterGroup: "5", contestReferences: ['c', 'd'] }
       };
 
       const cvr1 = { 'a': '1', 'b': '4' };

--- a/test/verifier/decrypt_ballot.test.ts
+++ b/test/verifier/decrypt_ballot.test.ts
@@ -1,7 +1,7 @@
 import { decrypt } from "../../lib/av_client/decrypt_vote";
-import { ContestConfig } from "../../lib/av_client/types";
+import { ContestConfigMap } from "../../lib/av_client/types";
 import { expect } from 'chai';
-const contestConfig : ContestConfig= {
+const contestConfig : ContestConfigMap = {
   "contest ref 1": {
       "markingType": {
           "style": "regular",

--- a/test/verifier/decrypt_ballot.test.ts
+++ b/test/verifier/decrypt_ballot.test.ts
@@ -3,6 +3,7 @@ import { ContestConfigMap } from "../../lib/av_client/types";
 import { expect } from 'chai';
 const contestConfig : ContestConfigMap = {
   "contest ref 1": {
+      "reference": "contest ref 1",
       "markingType": {
           "style": "regular",
           "codeSize": 1,


### PR DESCRIPTION
This PR introduces:
- ContestConfig has been changed to ContestConfigMap, and the type of the object attributes has been defined as ContestConfig
- BallotConfig has been changed to BallotConfigMap, and the type of the object attributes has been defined as BallotConfig.
