### PR TITLE
Vote encoding - part 3 (Adding byte_encoding and ContestSelection types)

### DIFF
--- a/lib/av_client/encoding/byte_encoding.ts
+++ b/lib/av_client/encoding/byte_encoding.ts
@@ -1,0 +1,84 @@
+import { ContestConfig, ContestSelection, OptionSelection, Option } from "../types"
+import { flattenOptions } from '../flatten_options'
+import { ByteArrayReader } from './byte_array_reader'
+import { ByteArrayWriter } from "./byte_array_writer"
+
+
+export function byteArrayToContestSelection( contestConfig: ContestConfig, byteArray: Uint8Array ): ContestSelection {
+  const { reference, markingType, options } = contestConfig
+  const codeSize = markingType.encoding.codeSize
+
+  const flatOptions = flattenOptions(options)
+  const referenceMap = extractReferenceMap(flatOptions)
+  const writeInMap = extractWriteInMap(flatOptions)
+
+  const optionSelections: OptionSelection[] = []
+
+  const reader = new ByteArrayReader(byteArray)
+
+  while( reader.hasMore() ){
+    const code = reader.readInteger(codeSize)
+    if( code === 0 ) throw new Error('ArgumentError: Unexpecked bytes found in byte array')
+
+    const reference = referenceMap[code]
+    if( !reference ) throw new Error('ArgumentError: Unexpected option code encountered')
+    // Is the selected option a write in?
+    const writeIn = writeInMap[reference]
+    if( writeIn ){
+      const text = reader.readString(writeIn.maxSize)
+      optionSelections.push({ reference, text: text })
+    } else {
+      optionSelections.push({ reference })
+    }
+  }
+
+  return {
+    reference,
+    optionSelections: optionSelections
+  }
+}
+
+
+export function contestSelectionToByteArray( contestConfig: ContestConfig, contestSelection: ContestSelection ): Uint8Array {
+  const { reference, markingType, options } = contestConfig
+  if( reference !== contestSelection.reference ){
+    throw new Error("contest selection does not match contest")
+  }
+
+  const flatOptions = flattenOptions(options)
+  const codeMap = extractCodeMap(flatOptions)
+  const writeInMap = extractWriteInMap(flatOptions)
+
+  const writer = new ByteArrayWriter(markingType.encoding.maxSize)
+
+  contestSelection.optionSelections.forEach(optionSelection => {
+    const writeIn = writeInMap[optionSelection.reference]
+    const code = codeMap[optionSelection.reference]
+
+    if( ! code ) throw new Error("Option reference not found")
+    if( writeIn && writeIn.encoding !== 'utf8' ) throw new Error(`Unsupported encoding '${writeIn.encoding}' for write in`)
+
+    writer.writeInteger(markingType.encoding.codeSize, code)
+
+    if( writeIn ){
+      const text = optionSelection.text || ''
+      writer.writeString(writeIn.maxSize, text)
+    } 
+  })
+
+  return writer.getByteArray()
+}
+
+
+function extractWriteInMap(flatOptions: Option[]){
+  const writeInOptions = flatOptions.filter(option => option.writeIn)
+  return Object.fromEntries(writeInOptions.map(option => [option.reference, option.writeIn]))
+}
+
+function extractCodeMap(flatOptions: Option[]){
+  return Object.fromEntries(flatOptions.map(option => [option.reference, option.code]))
+}
+
+function extractReferenceMap(flatOptions: Option[]){
+  return Object.fromEntries(flatOptions.map(option => [option.code, option.reference]))
+}

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -308,3 +308,13 @@ interface AffidavitConfig {
   curve: string;
   encryptionKey: string;
 }
+
+export type ContestSelection = {
+  reference: string
+  optionSelections: OptionSelection[]
+}
+
+export type OptionSelection = {
+  reference: string
+  text?: string
+}

--- a/test/encoding/byte_encoding.test.ts
+++ b/test/encoding/byte_encoding.test.ts
@@ -1,0 +1,123 @@
+import { contestSelectionToByteArray, byteArrayToContestSelection } from '../../lib/av_client/encoding/byte_encoding'
+import { expect } from 'chai'
+import { ContestConfig, ContestSelection } from '../../lib/av_client/types'
+
+const contestConfig: ContestConfig = {
+  reference: 'contest ref 1',
+  title: { en: 'Contest title' },
+  subtitle: { en: '' },
+  description: { en: '' },
+  markingType: {
+    minMarks: 1,
+    maxMarks: 3,
+    encoding: {
+      codeSize: 1,
+      maxSize: 20,
+      cryptogramCount: 1
+    }
+  },
+  resultType: {
+    name: 'does not matter for this test'
+  },
+  options: [
+    {
+      reference: 'ref1',
+      code: 1,
+      title: { en: 'Option 1' },
+      subtitle: { en: '' },
+      description: { en: '' }
+    },
+    {
+      reference: 'ref2',
+      code: 2,
+      title: { en: 'Option 2' },
+      subtitle: { en: '' },
+      description: { en: '' }
+    },
+    {
+      reference: 'ref3',
+      code: 3,
+      title: { en: 'Option 3 write in' },
+      subtitle: { en: '' },
+      description: { en: '' },
+      writeIn: {
+        maxSize: 10,
+        encoding: 'utf8'
+      }
+    }
+  ]
+}
+
+
+describe('contestSelectionToByteArray', () => {
+  it('returns a Uint8Array when given a ContestSelection', () => {
+    const contestSelection: ContestSelection = {
+      reference: 'contest ref 1',
+      optionSelections: [
+        { reference: 'ref2' },
+        { reference: 'ref3', text: 'hello' },
+        { reference: 'ref1' }
+      ]
+    }
+
+    expect(contestSelectionToByteArray(contestConfig, contestSelection).toString()).to.eq('2,3,104,101,108,108,111,0,0,0,0,0,1,0,0,0,0,0,0,0')
+  })
+  context('when selections are blank', () => {
+    const contestSelection: ContestSelection = {
+      reference: 'contest ref 1',
+      optionSelections: []
+    }
+    it('return a null-only byte array', () => {
+      expect(contestSelectionToByteArray(contestConfig, contestSelection).toString()).to.eq('0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0')
+    })
+  })
+  context('when selections does not match contest config', () => {
+    const contestSelection: ContestSelection = {
+      reference: 'contest ref mismatch',
+      optionSelections: []
+    }
+    
+    it('throws an error', () => {
+      expect(() => {
+        contestSelectionToByteArray(contestConfig, contestSelection)
+      }).to.throw('contest selection does not match contest')
+    })
+  })
+})
+
+describe('byteArrayToContestSelection', () => {
+  const byteArray = Uint8Array.of(2,3,104,101,108,108,111,0,0,0,0,0,1)
+  const contestSelection: ContestSelection = {
+    reference: 'contest ref 1',
+    optionSelections: [
+      { reference: 'ref2' },
+      { reference: 'ref3', text: 'hello' },
+      { reference: 'ref1' }
+    ]
+  }
+
+  it('returns a ContestSelection when given a valid Uint8Array', () => {
+    const result = byteArrayToContestSelection(contestConfig, byteArray)
+    expect(result).to.deep.equal(contestSelection)
+  })
+
+  context('when byte array contains padding', () => {
+    const byteArray = Uint8Array.of(2,3,104,101,108,108,111,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0)
+
+    it('returns a ContestSelection when given a valid Uint8Array', () => {
+      const result = byteArrayToContestSelection(contestConfig, byteArray)
+      expect(result).to.deep.equal(contestSelection)
+    })
+  })
+
+  context('when byte array contains an unexpected code', () => {
+
+    it('throws an error', () => {
+      const byteArray = Uint8Array.of(42)
+      expect(() => {
+
+        byteArrayToContestSelection(contestConfig, byteArray)
+      }).to.throw('ArgumentError: Unexpected option code encountered')
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces:
- High level encoder from ContestSelection to ByteArray
- ContestSelection and OptionSelection types (will in time replace CastVoteRecord)

The code is only mapped to tests at the moment, but a later pull request will tie it together with the other encoding parts