### PR TITLE
Align uniformer sorting with DBB

### DIFF
--- a/lib/util/uniformer.ts
+++ b/lib/util/uniformer.ts
@@ -10,7 +10,7 @@ export class Uniformer {
 
   private toSortedKeyValuePairs(obj: unknown) {
     const toKeyValueTuple = ([k, v]): KeyValuePair => [k, this.walk(v)];
-    const sortByKey = (a: KeyValuePair, b: KeyValuePair) => ("" + a[0]).localeCompare(b[0]);
+    const sortByKey = (a: KeyValuePair, b: KeyValuePair) => compareUtf8Strings(a[0], b[0])
 
     const properties = Object.entries(obj as Record<string, unknown>);
 
@@ -44,4 +44,33 @@ export class Uniformer {
         throw new Error(`Unknown parameter type '${typeof obj}'.`);
     }
   }
+}
+
+/**
+ * Compares two strings against eachother considering the utf8 bytes produced
+ * @param a string 1
+ * @param b string 2
+ * @returns -1, 0 or 1 depending on order
+ */
+function compareUtf8Strings(a: string, b: string){
+  return compare(
+    utf8StringToHex(a),
+    utf8StringToHex(b)
+  )
+}
+
+function compare(a, b){
+  if( a > b ) return 1
+  if( a < b ) return -1
+  return 0
+}
+
+/**
+ * Encodes a string from utf8 bytes to hex
+ * @param string string to encode from utf8 bytes to hex
+ * @returns hex representation of string
+ */
+function utf8StringToHex(string: string){
+  const array = new TextEncoder().encode(string)
+  return array.reduce((out, i) =>  out + ('0' + i.toString(16)).slice(-2), "")
 }

--- a/test/uniformer.test.ts
+++ b/test/uniformer.test.ts
@@ -3,7 +3,7 @@ import {Uniformer} from '../lib/util/uniformer';
 
 describe('Uniformer', () => {
   context('when object is a Hash', () => {
-    it('(deep) sorts hashes by keys and converts keys to string', async () => {
+    it('(deep) sorts hashes by keys and converts keys to string', () => {
       const unsortedProperties = {
         b: 2,
         a: 1,
@@ -26,6 +26,21 @@ describe('Uniformer', () => {
           ]
         ]
       ]));
+    })
+
+    it('sorts hashes by utf8 bytes of the string keys', () => {
+      const unsortedProperties = {
+        "a": 1,
+        "A": 1,
+        'z': 1,
+        'Z': 1,
+        'æ': 1,
+        'Æ': 1
+      }
+
+      const result = new Uniformer().formString(unsortedProperties);
+
+      expect(result).to.equal(JSON.stringify([["A",1],["Z",1],["a",1],["z",1],["Æ",1],["æ",1]]));
     })
   });
 


### PR DESCRIPTION
We need to sort the same in all uniformer implementations. To align with DBB we order strings by the utf8 bytes they are made of