### PR TITLE
Delete coverage badge generation from github CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,21 +17,6 @@ jobs:
         run: npm run lint
       - name: Run tests with coverage report
         run: npm run coverage
-      - name: Generate code coverage badge and commit it
-        if: success() && github.ref == 'refs/heads/main'
-        run: |
-          set -x
-          coverage_percentage=`cat coverage/coverage-summary.json | jq '.total.lines.pct'`
-          curl "https://img.shields.io/badge/coverage-$coverage_percentage%25-blue" > .github/coverage_badge.svg
-          if git status | grep coverage_badge.svg; then
-            echo 'Coverage changed'
-            git config --local user.email "action@github.com"
-            git config --local user.name "Github Action"
-            git add .github/coverage_badge.svg
-            git commit -m "Updated coverage badge to $coverage_percentage %"
-          else
-            echo 'Coverage remains the same'
-          fi
       - name: Private actions checkout
         uses: daspn/private-actions-checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,6 @@ jobs:
           else
             echo 'Coverage remains the same'
           fi
-      - name: Push committed coverage badge
-        if: success() && github.ref == 'refs/heads/main'
-        uses: ad-m/github-push-action@8407731efefc0d8f72af254c74276b7a90be36e1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
       - name: Private actions checkout
         uses: daspn/private-actions-checkout@v2
         with:


### PR DESCRIPTION
It is not working together with new branch protections where no commits must be done on main