### PR TITLE
Fixes package publish action maybe?

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-          cache: 'npm'
+          cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "webpack": "webpack --config webpack.config.js"
   },
   "files": [
-    "lib/**/*"
+    "dist/lib/**/*"
   ],
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "lint": "eslint lib/ test/",
     "webpack": "webpack --config webpack.config.js"
   },
+  "files": [
+    "lib/**/*"
+  ],
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
The action as a whole failed, but the package was published. The error was:

![image](https://user-images.githubusercontent.com/100691050/189135992-0882faa6-36b6-4e62-b1e8-ad244efbf60c.png)

The action that failed:
https://github.com/aion-dk/js-client/runs/8250137822?check_suite_focus=true#step:11:4

edit:
The package was not correctly published, and appears to be missing files. [This](https://stackoverflow.com/questions/65922489/how-is-npm-publish-different-from-yarn-publish) might be the answer, also included here