### PR TITLE
Refactoring types

### DIFF
--- a/lib/av_client/encoding/byte_encoding.ts
+++ b/lib/av_client/encoding/byte_encoding.ts
@@ -1,4 +1,4 @@
-import { ContestConfig, ContestSelection, OptionSelection, Option } from "../types"
+import { ContestConfig, ContestSelection, OptionSelection, OptionContent } from "../types"
 import { flattenOptions } from '../flatten_options'
 import { ByteArrayReader } from './byte_array_reader'
 import { ByteArrayWriter } from "./byte_array_writer"
@@ -70,15 +70,15 @@ export function contestSelectionToByteArray( contestConfig: ContestConfig, conte
 }
 
 
-function extractWriteInMap(flatOptions: Option[]){
+function extractWriteInMap(flatOptions: OptionContent[]){
   const writeInOptions = flatOptions.filter(option => option.writeIn)
   return Object.fromEntries(writeInOptions.map(option => [option.reference, option.writeIn]))
 }
 
-function extractCodeMap(flatOptions: Option[]){
+function extractCodeMap(flatOptions: OptionContent[]){
   return Object.fromEntries(flatOptions.map(option => [option.reference, option.code]))
 }
 
-function extractReferenceMap(flatOptions: Option[]){
+function extractReferenceMap(flatOptions: OptionContent[]){
   return Object.fromEntries(flatOptions.map(option => [option.code, option.reference]))
 }

--- a/lib/av_client/flatten_options.ts
+++ b/lib/av_client/flatten_options.ts
@@ -1,6 +1,6 @@
-import { Option } from './types';
+import { OptionContent } from './types';
 
-function flattenOption(option: Option){
+function flattenOption(option: OptionContent){
   const clone = { ...option }
   delete clone.children
 
@@ -8,7 +8,7 @@ function flattenOption(option: Option){
   return [clone].concat(flattenOptions(children))
 }
 
-export function flattenOptions(options: Option[]): Option[] {
-  const reducer = (list: Option[], option: Option) => list.concat(flattenOption(option))
+export function flattenOptions(options: OptionContent[]): OptionContent[] {
+  const reducer = (list: OptionContent[], option: OptionContent) => list.concat(flattenOption(option))
   return options.reduce(reducer, [])
 }

--- a/lib/av_client/option_finder.ts
+++ b/lib/av_client/option_finder.ts
@@ -1,12 +1,12 @@
 import { flattenOptions } from './flatten_options';
 import { InvalidOptionError } from './errors';
-import { Option } from './types'
+import { OptionContent } from './types'
 
-export function makeOptionFinder( options: Option[] ){
+export function makeOptionFinder( options: OptionContent[] ){
   const flatOptions = flattenOptions(options)
   const optionMap = extractOptionMap(flatOptions)
   
-  return ( reference: string ): Option => {
+  return ( reference: string ): OptionContent => {
     const option = optionMap[reference]
     if( option ) return option
 
@@ -14,6 +14,6 @@ export function makeOptionFinder( options: Option[] ){
   }
 }
 
-function extractOptionMap(flatOptions: Option[]){
+function extractOptionMap(flatOptions: OptionContent[]){
   return Object.fromEntries(flatOptions.map(option => [option.reference, option]))
 }

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -39,28 +39,28 @@ export type KeyPair = {
  */
 export type Affidavit = string
 
-export interface Ballot {
-  id: number;
-  vote_encoding_type: number;
-  title: LocalString;
-  description: LocalString;
-  options: Option[];
-  write_in: boolean;
-  //...
-}
+// export interface Ballot {
+//   id: number;
+//   vote_encoding_type: number;
+//   title: LocalString;
+//   description: LocalString;
+//   options: Option[];
+//   write_in: boolean;
+//   //...
+// }
 
-export interface Option {
-  reference: string;
-  code: number;
-  children?: Option[];
-  title: LocalString;
-  subtitle: LocalString;
-  description: LocalString;
-  writeIn?: {
-    maxSize: number
-    encoding: 'utf8'
-  }
-}
+// export interface Option {
+//   reference: string;
+//   code: number;
+//   children?: Option[];
+//   title: LocalString;
+//   subtitle?: LocalString;
+//   description?: LocalString;
+//   writeIn?: {
+//     maxSize: number
+//     encoding: 'utf8'
+//   }
+// }
 
 export interface LocalString {
   [locale: string]: string;
@@ -280,29 +280,47 @@ export interface LatestConfig {
 }
 
 export interface LatestConfigItems {
-  thresholdConfig: ThresholdConfig;
-  voterAuthorizerConfig: VoterAuthorizer;
-  ballotConfigs: BallotConfigMap;
-  contestConfigs: ContestConfigMap;
-  votingRoundConfigs: VotingRoundConfigMap;
-  electionConfig: ElectionConfig;
-  genesisConfig: GenesisConfig;
-  latestConfigItem: BaseBoardItem;
+  thresholdConfig: ThresholdConfig
+  voterAuthorizerConfig: VoterAuthorizer
+  ballotConfigs: BallotConfigMap
+  contestConfigs: ContestConfigMap
+  votingRoundConfigs: VotingRoundConfigMap
+  electionConfig: ElectionConfig
+  genesisConfig: GenesisConfig
+  latestConfigItem: BaseBoardItem
+  // segmentsConfig: SegmentsConfig
+  // extractionIntents: ExtractionIntents
+  // extractionData: ExtractionData
+  // extractionConfirmations: ExtractionConfirmations
 }
 
+interface PolynomialCoefficient {
+  degree: number
+  coefficient: string
+}
+
+interface Trustee {
+  publicKey: string
+  id: number
+  polynomialCoefficients: PolynomialCoefficient[]
+}
 
 // Threshold Config Item
-export interface ThresholdConfig {
+export interface ThresholdConfig extends BaseBoardItem {
   content: ThresholdConfigContent
+  type: 'ThresholdConfigItem'
 }
 
-export type ThresholdConfigContent = {
+export interface ThresholdConfigContent {
   encryptionKey: string
+  threshold: number
+  trustees: Trustee[]
 }
 
 // Voter Authorizer Item
-export interface VoterAuthorizer {
+export interface VoterAuthorizer extends BaseBoardItem {
   content: VoterAuthorizerContent
+  type: 'VoterAuthorizationConfigItem'
 } 
 
 export interface VoterAuthorizerContent {
@@ -318,12 +336,13 @@ export interface VoterAuthorizerContentItem {
 }
 
 // Ballot Config Item
-export type BallotConfigMap = {
+export interface BallotConfigMap {
   [voterGroupId: string]: BallotConfig
 }
 
-export type BallotConfig = {
+export interface BallotConfig extends BaseBoardItem {
   content: BallotContent
+  type: 'BallotConfigItem'
 }
 
 export interface BallotContent {
@@ -333,12 +352,13 @@ export interface BallotContent {
 }
 
 // Contest Config Item
-export type ContestConfigMap = {
+export interface ContestConfigMap {
   [contestReference: string]: ContestConfig
 }
 
-export type ContestConfig = {
+export interface ContestConfig extends BaseBoardItem {
   content: ContestContent
+  type: 'ContestConfigItem'
 }
 
 export interface ContestContent {
@@ -358,7 +378,7 @@ export interface ResultType {
 export interface OptionContent {
   reference: string;
   code: number;
-  children?: Option[];
+  children?: OptionContent[];
   title: LocalString;
   subtitle: LocalString;
   description: LocalString;
@@ -369,12 +389,13 @@ export interface OptionContent {
 }
 
 // Voting Round Config Item
-export type VotingRoundConfigMap = {
+export interface VotingRoundConfigMap {
   [votingRoundReference: string]: VotingRoundConfig
 }
 
-export type VotingRoundConfig = {
+export interface VotingRoundConfig extends BaseBoardItem {
   content: VotingRoundContent
+  type: 'VotingRoundConfigItem'
 }
 
 export interface VotingRoundContent {
@@ -389,11 +410,12 @@ export interface VotingRoundContent {
 }
 
 // Election Config Item
-export type ElectionConfig = {
+export interface ElectionConfig extends BaseBoardItem {
   content: ElectionConfigContent
+  type: 'ElectionConfigItem'
 }
 
-export interface ElectionConfigContent{
+export interface ElectionConfigContent {
   title: LocalString
   uuid: string
   status?: string
@@ -409,8 +431,11 @@ export interface ElectionConfigContent{
 }
 
 // Genesis Config Item
-export type GenesisConfig = {
+export interface GenesisConfig extends BaseBoardItem {
+  parentAddress: '0000000000000000000000000000000000000000000000000000000000000000'
+  previousAddress: '0000000000000000000000000000000000000000000000000000000000000000'
   content: GenesisConfigContent
+  type: 'GenesisItem'
 }
 
 export interface GenesisConfigContent {

--- a/lib/av_client/types.ts
+++ b/lib/av_client/types.ts
@@ -265,7 +265,7 @@ export interface LatestConfigItems {
   electionConfig: ElectionConfig
   genesisConfig: GenesisConfig
   latestConfigItem: LatestConfigurationConfig
-  segmentsConfig: SegmentsConfig | null
+  segmentsConfig: SegmentsConfigMap | null
   extractionIntents?: ExtractionIntents
   extractionData?: ExtractionData
   extractionConfirmations?: ExtractionConfirmations
@@ -279,6 +279,7 @@ export interface LatestConfigurationConfig extends BaseBoardItem {
     | 'VotingRoundConfigItem'
     | 'ElectionConfigItem'
     | 'GenesisItem'
+    | 'SegmentsConfigItem'
   content: VoterAuthorizerContent
     | ThresholdConfigContent
     | BallotContent
@@ -286,6 +287,7 @@ export interface LatestConfigurationConfig extends BaseBoardItem {
     | VotingRoundContent
     | ElectionConfigContent
     | GenesisConfigContent
+    | SegmentsConfigContent
 }
 
 // Threshold Config Item
@@ -451,7 +453,15 @@ export interface GenesisConfigContent {
 }
 
 // Segments Config Item
-export interface SegmentsConfig {
+export interface SegmentsConfigMap {
+  [segments: string]: SegmentsConfig
+}
+
+export interface SegmentsConfig extends BaseBoardItem {
+  content: SegmentsConfigContent
+  type: 'SegmentsConfigItem'
+}
+export interface SegmentsConfigContent {
   segments: string[]
 }
 

--- a/lib/av_client/validate_selections.ts
+++ b/lib/av_client/validate_selections.ts
@@ -1,4 +1,4 @@
-import { BallotConfig, BallotSelection, ContestSelection, OptionSelection, ContestConfig, ContestConfigMap, Option } from './types';
+import { BallotConfig, BallotSelection, ContestSelection, OptionSelection, ContestConfig, ContestConfigMap, OptionContent } from './types';
 import { flattenOptions } from './flatten_options'
 import { CorruptSelectionError as CorruptSelectionError } from './errors';
 
@@ -71,7 +71,7 @@ function validateContestsMatching( ballotConfig: BallotConfig, ballotSelection: 
   }
 }
 
-function makeGetOption(options: Option[]){
+function makeGetOption(options: OptionContent[]){
   const flatOptions = flattenOptions(options)
   const referenceMap = Object.fromEntries(flatOptions.map(o => [o.reference, o]))
 

--- a/test/benaloh_flow.test.ts
+++ b/test/benaloh_flow.test.ts
@@ -18,8 +18,8 @@ describe.skip('entire benaloh flow', () => {
   });
 
   it('spoils a ballot', async () => {
-    const verifier = new AVVerifier(bulletinBoardHost + 'us');
-    const client = new AVClient(bulletinBoardHost + 'us');
+    const verifier = new AVVerifier(bulletinBoardHost + 'usa');
+    const client = new AVClient(bulletinBoardHost + 'usa');
 
     await verifier.initialize()
     await client.initialize(undefined, {
@@ -57,11 +57,8 @@ describe.skip('entire benaloh flow', () => {
 
     expect(contestSelections).to.eql([
       {
-        reference: 'contest ref 1',
-        optionSelections: [{reference: 'option ref 1'}]
-      },{
-        reference: 'contest ref 2',
-        optionSelections: [{reference: 'option ref 3'}]
+        reference: 'recqPa7AeyufIfd6k',
+        optionSelections: [{reference: 'recysACFx8cgwomBE'}]
       }
     ]);
 
@@ -69,24 +66,9 @@ describe.skip('entire benaloh flow', () => {
 
     expect(readableContestSelections).to.deep.equal([
       {
-        "reference": "contest ref 1",
-        "title": "First ballot",
-        "optionSelections": [
-          {
-            "reference": "option ref 1",
-            "title": "Option 1"
-          }
-        ]
-      },
-      {
-        "reference": "contest ref 2",
-        "title": "Second ballot",
-        "optionSelections": [
-          {
-            "reference": "option ref 3",
-            "title": "Option 3"
-          }
-        ]
+        reference: 'recqPa7AeyufIfd6k',
+        title: 'Air Traffic Control Tax Increase',
+        optionSelections: [ { reference: 'recysACFx8cgwomBE', title: 'Yes' } ]
       }
     ]);
 

--- a/test/benaloh_flow.test.ts
+++ b/test/benaloh_flow.test.ts
@@ -18,8 +18,8 @@ describe.skip('entire benaloh flow', () => {
   });
 
   it('spoils a ballot', async () => {
-    const verifier = new AVVerifier(bulletinBoardHost + 'usa');
-    const client = new AVClient(bulletinBoardHost + 'usa');
+    const verifier = new AVVerifier(bulletinBoardHost + 'us');
+    const client = new AVClient(bulletinBoardHost + 'us');
 
     await verifier.initialize()
     await client.initialize(undefined, {
@@ -57,8 +57,11 @@ describe.skip('entire benaloh flow', () => {
 
     expect(contestSelections).to.eql([
       {
-        reference: 'recqPa7AeyufIfd6k',
-        optionSelections: [{reference: 'recysACFx8cgwomBE'}]
+        reference: 'contest ref 1',
+        optionSelections: [{reference: 'option ref 1'}]
+      },{
+        reference: 'contest ref 2',
+        optionSelections: [{reference: 'option ref 3'}]
       }
     ]);
 
@@ -66,9 +69,24 @@ describe.skip('entire benaloh flow', () => {
 
     expect(readableContestSelections).to.deep.equal([
       {
-        reference: 'recqPa7AeyufIfd6k',
-        title: 'Air Traffic Control Tax Increase',
-        optionSelections: [ { reference: 'recysACFx8cgwomBE', title: 'Yes' } ]
+        "reference": "contest ref 1",
+        "title": "First ballot",
+        "optionSelections": [
+          {
+            "reference": "option ref 1",
+            "title": "Option 1"
+          }
+        ]
+      },
+      {
+        "reference": "contest ref 2",
+        "title": "Second ballot",
+        "optionSelections": [
+          {
+            "reference": "option ref 3",
+            "title": "Option 3"
+          }
+        ]
       }
     ]);
 

--- a/test/construct_contest_envelopes.test.ts
+++ b/test/construct_contest_envelopes.test.ts
@@ -4,6 +4,13 @@ import { ContestConfig, BallotConfig, ClientState } from '../lib/av_client/types
 import latestConfig from './fixtures/latestConfig';
 
 const contestOne: ContestConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'ContestConfigItem',
   content: {
     reference: 'contest-1',
     markingType: {
@@ -35,6 +42,13 @@ const contestOne: ContestConfig = {
 }
 
 const ballotOne: BallotConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'BallotConfigItem',
   content: {
     reference: 'ballot-1',
     voterGroup: '1',

--- a/test/construct_contest_envelopes.test.ts
+++ b/test/construct_contest_envelopes.test.ts
@@ -70,7 +70,8 @@ const clientState: ClientState = {
       electionConfig: latestConfig.items.electionConfig,
       genesisConfig: latestConfig.items.genesisConfig,
       latestConfigItem: latestConfig.items.latestConfigItem,
-      votingRoundConfigs: latestConfig.items.votingRoundConfigs
+      votingRoundConfigs: latestConfig.items.votingRoundConfigs,
+      segmentsConfig: null
     }
   },
   voterSession: {

--- a/test/decrypt_contest_selections.test.ts
+++ b/test/decrypt_contest_selections.test.ts
@@ -6,6 +6,13 @@ import { CommitmentOpening, ContestConfig, ContestConfigMap, ContestEnvelope, Co
 const encryptionKey = '021edaa87d7626dbd2faa99c4dc080f443c150ab70b24da411b13aa56249b5242e'
 
 const bigContest: ContestConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'ContestConfigItem',
   content: {
     reference: 'big-contest',
     markingType: {

--- a/test/encoding/byte_encoding.test.ts
+++ b/test/encoding/byte_encoding.test.ts
@@ -3,6 +3,13 @@ import { expect } from 'chai'
 import { ContestConfig, ContestSelection } from '../../lib/av_client/types'
 
 const contestConfig: ContestConfig = {
+    address: '',
+    author: '',
+    parentAddress: '',
+    previousAddress: '',
+    registeredAt: '',
+    signature: '',
+    type: 'ContestConfigItem',
     content: {
       reference: 'contest ref 1',
       title: { en: 'Contest title' },

--- a/test/encrypt_contest_selections.test.ts
+++ b/test/encrypt_contest_selections.test.ts
@@ -5,6 +5,13 @@ import { ContestConfig, ContestConfigMap } from '../lib/av_client/types';
 const encryptionKey = '021edaa87d7626dbd2faa99c4dc080f443c150ab70b24da411b13aa56249b5242e'
 
 const contestOne: ContestConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'ContestConfigItem',
   content: {
     reference: 'contest-1',
     markingType: {
@@ -66,6 +73,13 @@ describe('encryptContestSelections', () => {
 
   context('when given a contest selection for a contest that uses 2 cryptograms', () => {
     const bigContest: ContestConfig = {
+      address: '',
+      author: '',
+      parentAddress: '',
+      previousAddress: '',
+      registeredAt: '',
+      signature: '',
+      type: 'ContestConfigItem',
       content: {
         reference: 'big-contest',
         markingType: {

--- a/test/fixtures/latestConfig.ts
+++ b/test/fixtures/latestConfig.ts
@@ -3,11 +3,27 @@ import { LatestConfig } from '../../lib/av_client';
 const latestConfig: LatestConfig = {
   items: {
     thresholdConfig: {
+      address: '',
+      author: '',
+      parentAddress: '',
+      previousAddress: '',
+      registeredAt: '',
+      signature: '',
+      type: 'ThresholdConfigItem',
       content: {
-        encryptionKey: "03d8c46ae42cd7f95009ddf444eebc5b18e2cad34aad94129ffc54b5606b5638f4"
+        encryptionKey: "03d8c46ae42cd7f95009ddf444eebc5b18e2cad34aad94129ffc54b5606b5638f4",
+        threshold: 1,
+        trustees: []
       }
     },
     voterAuthorizerConfig: {
+      address: '',
+      author: '',
+      parentAddress: '',
+      previousAddress: '',
+      registeredAt: '',
+      signature: '',
+      type: 'VoterAuthorizationConfigItem',
       content: {
         identityProvider: {
           contextUuid: "adb99ef7-7992-4bc9-a54b-239d64d97f91",
@@ -24,6 +40,13 @@ const latestConfig: LatestConfig = {
     },
     ballotConfigs: {
       precinct_4_bedrock: {
+        address: '',
+        author: '',
+        parentAddress: '',
+        previousAddress: '',
+        registeredAt: '',
+        signature: '',
+        type: 'BallotConfigItem',
         content: {
           reference: "precinct_4_bedrock",
           voterGroup: "precinct_4_bedrock",
@@ -36,6 +59,13 @@ const latestConfig: LatestConfig = {
     },
     contestConfigs: {
       "contest ref 1": {
+        address: '',
+        author: '',
+        parentAddress: '',
+        previousAddress: '',
+        registeredAt: '',
+        signature: '',
+        type: 'ContestConfigItem',
         content: {
           reference: "contest ref 1",
           title: {
@@ -91,6 +121,13 @@ const latestConfig: LatestConfig = {
         }
       },
       "contest ref 2": {
+        address: '',
+        author: '',
+        parentAddress: '',
+        previousAddress: '',
+        registeredAt: '',
+        signature: '',
+        type: 'ContestConfigItem',
         content: {
           reference: "contest ref 2",
           title: {
@@ -147,15 +184,33 @@ const latestConfig: LatestConfig = {
       },
     },
     electionConfig: {
+      address: '',
+      author: '',
+      parentAddress: '',
+      previousAddress: '',
+      registeredAt: '',
+      signature: '',
+      type: 'ElectionConfigItem',
       content: {
         title: {
           en: "Some US Election"
         },
         uuid: "bc1b1ed0-943e-4647-bfc1-0633ba08c05e",
+        status: "scheduled",
+        locales: [
+          "en"
+        ],
       }
     },
     votingRoundConfigs: {
       "voting-round-1": {
+        address: '',
+        author: '',
+        parentAddress: '',
+        previousAddress: '',
+        registeredAt: '',
+        signature: '',
+        type: 'VotingRoundConfigItem',
         content: {
           status: "open",
           reference: "voting-round-1",
@@ -165,6 +220,13 @@ const latestConfig: LatestConfig = {
       }
     },
     genesisConfig: {
+      address: '',
+      author: '',
+      parentAddress: '0000000000000000000000000000000000000000000000000000000000000000',
+      previousAddress: '0000000000000000000000000000000000000000000000000000000000000000',
+      registeredAt: '',
+      signature: '',
+      type: 'GenesisItem',
       content: {
         ballotAcceptance: "inferred",
         eaCurveName: "secp256k1",
@@ -174,13 +236,29 @@ const latestConfig: LatestConfig = {
         resultExtraction: "throughout-election"
       }
     },
+    segmentsConfig: null,
+    extractionIntents: {},
+    extractionData: {},
+    extractionConfirmations: {},
     latestConfigItem: {
-      address: "0e4cc630c0fd8f6ca3f4a2f4329ab440969044a7dd470038f6c5ae17c5f6ed23",
+      address: "f777803fa83e8f79141becb3858cf23e28a1fd6e701b94eb6c20aa2fcd9f58c1",
       author: "Election Admin App",
-      parentAddress: "dfd82ccd645048358fe92cb48988ee4487fdd390fb657bf68733fae9bf308cfd",
-      previousAddress: "dfd82ccd645048358fe92cb48988ee4487fdd390fb657bf68733fae9bf308cfd",
-      registeredAt: "2022-11-30T13:57:38.451Z",
-      signature: "ccb3e5af13908cdbff5b41b0e5a349bddb573adc017fa4f0ba436c45c3b7f7f8,18f361cc6944ffae8ab0b9f34e8b1c49a5bb78fb0a09889e1ab405d183b11e9b",
+      parentAddress: "35629e3960fb05b7ddbb27ec161ef74581b2be4e1345477f0c9be2c38f2d17be",
+      previousAddress: "35629e3960fb05b7ddbb27ec161ef74581b2be4e1345477f0c9be2c38f2d17be",
+      content: {
+        encryptionKey: "0220f81d43002c88229ed8c80cfc7f84f9700ee13d80e1be1cd8a3677f84e99ae1",
+        threshold: 1,
+        trustees: [
+          {
+            publicKey: "0220f81d43002c88229ed8c80cfc7f84f9700ee13d80e1be1cd8a3677f84e99ae1",
+            id: 6,
+            polynomialCoefficients: []
+          }
+        ]
+      },
+      registeredAt: "2022-12-21T13:26:04.894Z",
+      signature: "b9941eac0965bcac23b935206a934fec07aeac1f12d785868b9cfe49c54bca8d,25250822e9b315b9db3c71cd81092c1ee2175e1d591a95bf1a391bdc84821722",
+      type: "ThresholdConfigItem"
     }
   },
 };

--- a/test/validate_selections.test.ts
+++ b/test/validate_selections.test.ts
@@ -4,6 +4,13 @@ import { ContestConfig, BallotSelection, BallotConfig, ContestConfigMap } from '
 import { CorruptSelectionError } from '../lib/av_client/errors'
 
 const contestOne: ContestConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'ContestConfigItem',
   content: {
     reference: 'contest-1',
     markingType: {
@@ -42,6 +49,13 @@ const contestOne: ContestConfig = {
 }
 
 const contestTwo: ContestConfig = {
+  address: '',
+  author: '',
+  parentAddress: '',
+  previousAddress: '',
+  registeredAt: '',
+  signature: '',
+  type: 'ContestConfigItem',
   content: {
     reference: 'contest-2',
     markingType: {
@@ -180,6 +194,13 @@ describe('validateContestSelection', () => {
 
 describe('validateBallotSelection', () => {
   const ballotConfig: BallotConfig = {
+    address: '',
+    author: '',
+    parentAddress: '',
+    previousAddress: '',
+    registeredAt: '',
+    signature: '',
+    type: 'BallotConfigItem',
     content: {
       reference: 'ballot-1',
       voterGroup: '4',


### PR DESCRIPTION
It is necessary to have correct typing on the JS-client because other applications are importing them. This also helps to have typing management centralized in one file when updating the format of the Config Items.