### PR TITLE
Adding Global editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+tab_width = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
This standardizes our editors with the same settings as to how to treat common settings, like:

* Line endings;
* Blank spaces;
* Tabs vs Spaces;
* ...and more.