### PR TITLE
Replace 'jose' dependency with 'auth0/jwt-decode'

### DIFF
--- a/lib/av_client.ts
+++ b/lib/av_client.ts
@@ -7,8 +7,8 @@ import { constructContestEnvelopes } from './av_client/construct_contest_envelop
 import { KeyPair, Affidavit, VerifierItem, CommitmentOpening, SpoilRequestItem, LatestConfig, BallotSelection, ContestEnvelope, BallotConfig, BallotStatus, ContestConfig } from './av_client/types';
 import { randomKeyPair } from './av_client/generate_key_pair';
 import { generateReceipt } from './av_client/generate_receipt';
-import * as jwt from 'jose';
 import { Buffer } from 'buffer'
+import jwtDecode, { JwtPayload } from "jwt-decode";
 
 import {
   fetchLatestConfig,
@@ -227,7 +227,7 @@ export class AVClient implements IAVClient {
 
     const { authToken } = authorizationResponse.data;
 
-    const decoded = jwt.decodeJwt(authToken); // TODO: Verify against dbb pubkey: this.getLatestConfig().services.voterAuthorizer.public_key);
+    const decoded = jwtDecode<JwtPayload>(authToken); // TODO: Verify against dbb pubkey: this.getLatestConfig().services.voterAuthorizer.public_key);
 
     if(decoded === null)
       throw new InvalidTokenError('Auth token could not be decoded');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "axios": "^0.25.0",
     "base-x": "^4.0.0",
     "buffer": "^6.0.3",
-    "jose": "^4.6.0",
+    "jwt-decode": "^3.1.2",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,11 +1780,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jose@^4.6.0:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.9.2.tgz#268994df4443b9c191de0b001c2e3796ac6cf368"
-  integrity sha512-EqKvu2PqJCD3Jrg3PvcYZVS7D21qMVLSYMDAFcOdGUEOpJSLNtJO7NjLANvu3SYHVl6pdP2ff7ve6EZW2nX7Nw==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1844,6 +1839,11 @@ just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
 kind-of@^6.0.2:
   version "6.0.3"


### PR DESCRIPTION
Replaces 'jose' dependency with 'auth0/jwt-decode' to handle jwt decoding. 'jose' does not work with React Native.