### PR TITLE
hkdf working

### DIFF
--- a/lib/av_crypto/key_derivation.ts
+++ b/lib/av_crypto/key_derivation.ts
@@ -1,11 +1,20 @@
 import {BitArray} from "./sjcl";
 import * as sjcl from "sjcl-with-all";
+import { hkdf as noble_hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha256';
 
-
-export function pbkdf2(password: string, keyBitLength: number): BitArray {
-  return sjcl.misc.pbkdf2(password, '', 10_000, keyBitLength)
+export function pbkdf2(password: string, keyByteLength: number): BitArray {
+  return sjcl.misc.pbkdf2(password, '', 10_000, keyByteLength * 8)
 }
 
-export function hkdf(inputKey: BitArray, keyBitLength: number): BitArray {
-  return sjcl.misc.hkdf(inputKey, keyBitLength, '', '', sjcl.hash.sha256)
+export function hkdf(inputKey: BitArray, keyByteLength: number): BitArray {
+  const key = noble_hkdf(
+    sha256,
+    new Uint8Array(sjcl.codec.bytes.fromBits(inputKey)),
+    '',
+    '',
+    keyByteLength
+  );
+
+  return sjcl.codec.bytes.toBits(key)
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "buffer": "^6.0.3",
     "jwt-decode": "^3.1.2",
     "xml-js": "^1.6.11",
-    "sjcl-with-all": "^1.0.8"
+    "sjcl-with-all": "^1.0.8",
+    "@noble/hashes": "^1.3.1"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/test/av_crypto/key_derivation.test.ts
+++ b/test/av_crypto/key_derivation.test.ts
@@ -1,28 +1,37 @@
 import { expect } from "chai";
 import {hkdf, pbkdf2} from "../../lib/av_crypto/key_derivation";
 import * as sjcl from "sjcl-with-all";
+import {hexString} from "./test_helpers";
 
 describe("Key Derivation", () => {
 
   describe("pbkdf2()", () => {
-    const keyBitLength = 256
+    const keyByteLength = 32
     const password = "Chamber of Secrets"
 
     it ("has the right bit size", () => {
-      const key = pbkdf2(password, keyBitLength)
+      const key = pbkdf2(password, keyByteLength)
 
-      expect(sjcl.bitArray.bitLength(key)).to.equal(keyBitLength)
+      expect(sjcl.bitArray.bitLength(key)).to.equal(keyByteLength * 8)
+      expect(sjcl.codec.hex.fromBits(key)).to.equal(hexString(
+        "750c0ca7 c15d771d 185ec0a8 a146ec84" +
+        "cb94cc9d 57277a82 5e218dfa 28281a22"
+      ));
     })
   })
 
   describe("hkdf()", () => {
-    const keyBitLength = 256
+    const keyByteLength = 32
     const inputKey = sjcl.codec.utf8String.toBits("my secret key")
 
     it("has the right bit size", () => {
-      const key = hkdf(inputKey, keyBitLength)
+      const key = hkdf(inputKey, keyByteLength)
 
-      expect(sjcl.bitArray.bitLength(key)).to.equal(keyBitLength)
+      expect(sjcl.bitArray.bitLength(key)).to.equal(keyByteLength * 8)
+      expect(sjcl.codec.hex.fromBits(key)).to.equal(hexString(
+        "eb0bcf6a 52734168 196b07e8 a078b979" +
+        "b336e78b 4c3d2147 189f664e 34925d7b"
+      ));
     })
   })
 })


### PR DESCRIPTION
It seems reasonable to use the `@noble/hashes` external package for HKDF functionality.
The package also has an implementation of SHA384, which we need anyway. 