### PR TITLE
Add locale for sendReceipt

### DIFF
--- a/lib/av_client.ts
+++ b/lib/av_client.ts
@@ -420,6 +420,7 @@ export class AVClient implements IAVClient {
    *
    *
    * @param affidavit The {@link Affidavit | affidavit} document.
+   * @param locale The locale which the email with the vote receipt should be sent in
    * @return Returns the vote receipt. Example of a receipt:
    * ```javascript
    * {
@@ -432,7 +433,7 @@ export class AVClient implements IAVClient {
    * ```
    * @throws {@link NetworkError | NetworkError } if any request failed to get a response
    */
-    public async castBallot(affidavit?: Affidavit): Promise<BallotBoxReceipt> {
+    public async castBallot(affidavit?: Affidavit, locale = "en"): Promise<BallotBoxReceipt> {
       // Affidavit must be base64 encoded
 
       if(!(this.voterSession)) {
@@ -475,7 +476,7 @@ export class AVClient implements IAVClient {
         const voterAuthorizerContextUuid = this.getLatestConfig().items.voterAuthorizerConfig.content.voterAuthorizer.contextUuid;
         const coordinator = new VoterAuthorizationCoordinator(coordinatorURL, voterAuthorizerContextUuid);
         try {
-          coordinator.sendReceipt(clientReceipt, this.authorizationSessionId, this.getLatestConfig().items.electionConfig.content.dbasUrl);
+          coordinator.sendReceipt(clientReceipt, this.authorizationSessionId, this.getLatestConfig().items.electionConfig.content.dbasUrl, locale);
         } catch(e) {
           console.error(e)
         }

--- a/lib/av_client/connectors/voter_authorization_coordinator.ts
+++ b/lib/av_client/connectors/voter_authorization_coordinator.ts
@@ -53,8 +53,8 @@ export default class VoterAuthorizationCoordinator {
     });
   }
 
-  sendReceipt(receipt: BallotBoxReceipt, authorizationSessionId: string, dbasUrl?: string ): Promise<AxiosResponse> {
-    return this.backend.post('send_receipt', {
+  sendReceipt(receipt: BallotBoxReceipt, authorizationSessionId: string, dbasUrl?: string, locale = "en"): Promise<AxiosResponse> {
+    return this.backend.post(`${locale}/send_receipt`, {
       trackingCode: receipt.trackingCode,
       electionContextUuid: this.electionContextUuid,
       authorizationSessionId: authorizationSessionId,


### PR DESCRIPTION
Working with changing locales was not a consideration for US, meaning the structure is not well suited for client side changes to the locale. 

Ideally the AVClient should be instantiated with a locale we can simply access, but it would also have to be updated if the outer UI changes locale...